### PR TITLE
feat: fechos empresa no horário, badge pendentes tutor, ordenação e correção badge sumários

### DIFF
--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -28,6 +28,7 @@ import {
   weekdayLabel,
   type WorkDay,
 } from "@/lib/estagios/workdays";
+import type { ScheduleChangeRequest } from "@/lib/estagios/schedule-change-requests";
 import type { EstagioRole } from "@/lib/estagios/permissions";
 
 type Props = {
@@ -60,9 +61,42 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
   const totalHoras = Number(estagio.totalHoras ?? 0) || 0;
   const dias = useMemo(() => normalizeDiasSemana(estagio.diasSemana), [estagio.diasSemana]);
 
+  const [fechoExcludedDates, setFechoExcludedDates] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let unsub: (() => void) | undefined;
+    let cancelled = false;
+    (async () => {
+      const db = await getDbRuntime();
+      if (cancelled) return;
+      unsub = onSnapshot(
+        collection(db, "estagios", estagioId, "schedule_change_requests"),
+        (snap) => {
+          const dates = new Set<string>();
+          snap.forEach((d) => {
+            const req = d.data() as ScheduleChangeRequest;
+            if (req.type === "future_absence" && req.status === "approved") {
+              if (req.targetDate) dates.add(req.targetDate);
+            }
+          });
+          setFechoExcludedDates(dates);
+        },
+        (err) => {
+          if ((err as { code?: string }).code !== "permission-denied") {
+            console.error("[horario] schedule_change_requests snapshot", err);
+          }
+        }
+      );
+    })();
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, [estagioId]);
+
   const workDays = useMemo(
-    () => listWorkDays(dataInicio, dataFim, dias),
-    [dataInicio, dataFim, dias]
+    () => listWorkDays(dataInicio, dataFim, dias, fechoExcludedDates),
+    [dataInicio, dataFim, dias, fechoExcludedDates]
   );
   const weeks = useMemo(() => groupWorkDaysByWeek(workDays), [workDays]);
 

--- a/components/estagios/sumarios-tab.tsx
+++ b/components/estagios/sumarios-tab.tsx
@@ -373,7 +373,7 @@ export function SumariosTab({
             const isFuture = week.weekStartIso > todayIso;
             const error = errors[week.weekId];
             const isSavedFlash = savedFlash === week.weekId;
-            const isArchived = persisted?.estado === "arquivado";
+            const isArchived = persisted?.estado === "arquivado" || persisted?.signedByTutor === true;
             const status = isArchived
               ? { label: "Arquivado", variant: "default" as const }
               : persisted?.content

--- a/components/layout/tutor-layout.tsx
+++ b/components/layout/tutor-layout.tsx
@@ -14,6 +14,7 @@ import { ChatNavUnreadBadge } from "@/components/chat/chat-nav-unread-badge";
 import { NotificationsInbox } from "@/components/chat/notifications-inbox";
 import { useChatNotifications } from "@/lib/chat/use-chat-notifications";
 import { usePendingSummaries } from "@/lib/estagios/use-pending-summaries";
+import { usePendingRequests } from "@/lib/estagios/use-pending-requests";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -61,7 +62,7 @@ export function TutorLayout({ children }: { children: React.ReactNode }) {
   const navItems = [
     { href: "/tutor", label: "Dashboard", icon: LayoutDashboard },
     { href: "/tutor/inbox", label: "Caixa de Entrada", icon: Inbox },
-    { href: "/tutor/solicitacoes-horario", label: "Solicitações de horário", icon: CalendarClock },
+    { href: "/tutor/solicitacoes-horario", label: "Sol. Mudança Hor.", icon: CalendarClock },
     { href: "/tutor/estagios", label: "Estágios", icon: Briefcase },
     { href: "/tutor/sumarios", label: "Validação de sumários", icon: FileText },
     { href: "/tutor/chat", label: "Chat", icon: MessageSquare },
@@ -71,6 +72,7 @@ export function TutorLayout({ children }: { children: React.ReactNode }) {
   const isChatPage = pathname === "/tutor/chat" || pathname.startsWith("/tutor/chat/");
 
   const pendingSummariesCount = usePendingSummaries(state.userId);
+  const pendingRequestsCount = usePendingRequests(state.userId);
 
   const { notifications, handleOpenConversation } = useChatNotifications({
     userId: state.userId,
@@ -177,6 +179,11 @@ export function TutorLayout({ children }: { children: React.ReactNode }) {
                   {item.href === "/tutor/sumarios" && pendingSummariesCount > 0 && (
                     <span className="ml-2 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-[10px] font-medium text-destructive-foreground">
                       {pendingSummariesCount}
+                    </span>
+                  )}
+                  {item.href === "/tutor/solicitacoes-horario" && pendingRequestsCount > 0 && (
+                    <span className="ml-2 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-[10px] font-medium text-destructive-foreground">
+                      {pendingRequestsCount}
                     </span>
                   )}
                 </Link>

--- a/components/tutor/tutor-requests-center.tsx
+++ b/components/tutor/tutor-requests-center.tsx
@@ -67,7 +67,12 @@ export function TutorRequestsCenter() {
         requests: ScheduleChangeRequest[];
       };
       if (!json.ok) return;
-      const out = json.requests.sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
+      const out = json.requests.sort((a, b) => {
+        const aPending = a.status === "pending_tutor" ? 0 : 1;
+        const bPending = b.status === "pending_tutor" ? 0 : 1;
+        if (aPending !== bPending) return aPending - bPending;
+        return toMillis(b.createdAt) - toMillis(a.createdAt);
+      });
       setRequests(out);
       setLoadingRequests(false);
     } catch (err) {

--- a/lib/estagios/use-pending-requests.ts
+++ b/lib/estagios/use-pending-requests.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+import { collection, onSnapshot, query, where } from "firebase/firestore";
+import { getDbRuntime } from "@/lib/firebase-runtime";
+
+export function usePendingRequests(userId: string | undefined) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!userId) {
+      setCount(0);
+      return;
+    }
+
+    let unsub = () => {};
+    let isCancelled = false;
+
+    (async () => {
+      const db = await getDbRuntime();
+      if (isCancelled) return;
+
+      const estagiosQuery = query(collection(db, "estagios"), where("tutorId", "==", userId));
+
+      unsub = onSnapshot(
+        estagiosQuery,
+        (estagiosSnap) => {
+          if (isCancelled) return;
+
+          const estagioIds = estagiosSnap.docs.map((doc) => doc.id);
+
+          if (estagioIds.length === 0) {
+            setCount(0);
+            return;
+          }
+
+          const unsubs: Array<() => void> = [];
+          const countsByEstagio = new Map<string, number>();
+
+          const updateCount = () => {
+            let c = 0;
+            for (const v of countsByEstagio.values()) c += v;
+            setCount(c);
+          };
+
+          for (const estagioId of estagioIds) {
+            const requestsQuery = query(
+              collection(db, "estagios", estagioId, "schedule_change_requests"),
+              where("status", "==", "pending_tutor")
+            );
+
+            const u = onSnapshot(
+              requestsQuery,
+              (snap) => {
+                countsByEstagio.set(estagioId, snap.docs.length);
+                updateCount();
+              },
+              () => {}
+            );
+
+            unsubs.push(u);
+          }
+
+          unsub = () => {
+            for (const u of unsubs) u();
+          };
+        },
+        () => {}
+      );
+    })();
+
+    return () => {
+      isCancelled = true;
+      unsub();
+    };
+  }, [userId]);
+
+  return count;
+}

--- a/lib/estagios/workdays.ts
+++ b/lib/estagios/workdays.ts
@@ -126,7 +126,8 @@ export type WorkWeek = {
 export function listWorkDays(
   dataInicio: string,
   dataFim: string,
-  diasSemana: DiasSemanaMap
+  diasSemana: DiasSemanaMap,
+  excludedDates?: Set<string>
 ): WorkDay[] {
   const start = parseIsoDate(dataInicio);
   const end = parseIsoDate(dataFim);
@@ -147,7 +148,7 @@ export function listWorkDays(
     const key = WEEKDAY_KEYS[weekday];
     const isWorkday = Boolean(diasSemana[key]);
     const isHoliday = holidays.has(iso);
-    if (isWorkday && !isHoliday) {
+    if (isWorkday && !isHoliday && !excludedDates?.has(iso)) {
       const isoWeek = getIsoWeek(cursor);
       const relativeWeekNumber = getRelativeWeekNumber(cursor, start);
       const weekStart = getIsoWeekStart(cursor);


### PR DESCRIPTION
### 1. Fechos da empresa no horário (dias sem estágio)
- **`listWorkDays()`** (`lib/estagios/workdays.ts`) — parâmetro opcional `excludedDates?: Set<string>`
- **`HorarioTab`** (`components/estagios/horario-tab.tsx`) — nova subscription `onSnapshot` à subcoleção `schedule_change_requests`; dias com `type === "future_absence" && status === "approved"` são excluídos da tabela de presenças (tal como feriados)
- Efeito reversível em tempo real: tutor remove fecho → request vira `cancelled` → dia reaparece
### 2. Badge de sumários corrigida
- **`SumariosTab`** (`components/estagios/sumarios-tab.tsx:376`) — `isArchived` passou a considerar também `signedByTutor === true`, não apenas `estado === "arquivado"`. Resolve casos de sumários validados pelo tutor que mostravam "Preenchido" em vez de "Arquivado"
### 3. Badge de solicitações pendentes na nav do tutor
- **`usePendingRequests`** (`lib/estagios/use-pending-requests.ts`) — novo hook que conta `schedule_change_requests` com `status === "pending_tutor"` em tempo real via `onSnapshot`
- **`TutorLayout`** (`components/layout/tutor-layout.tsx:64`) — label da nav encurtada para "Sol. Mudança Hor."
- **`TutorLayout`** (`components/layout/tutor-layout.tsx:182-187`) — badge destrutivo com contagem de pedidos pendentes
### 4. Ordenação na página de solicitações do tutor
- **`TutorRequestsCenter`** (`components/tutor/tutor-requests-center.tsx:70-76`) — sort alterado: pedidos `pending_tutor` aparecem primeiro; dentro do mesmo estado, ordenação por data descendente (mais recentes primeiro)