### PR TITLE
fix: Calendário

### DIFF
--- a/app/api/estagios/[id]/recalcular-data-fim/route.ts
+++ b/app/api/estagios/[id]/recalcular-data-fim/route.ts
@@ -95,7 +95,17 @@ export async function POST(
       });
     }
 
-    // Atualizar no Firestore
+    // Só atualizar Firestore se o valor mudou (evita cascatas de snapshot).
+    const currentDataFim = estagioData.dataFimEstimada as string | undefined;
+    if (newDataFim === currentDataFim) {
+      return NextResponse.json({
+        ok: true,
+        recalculado: false,
+        motivo: "Data fim já está correta.",
+        dataFimEstimada: newDataFim,
+      });
+    }
+
     await estagioRef.update({
       dataFimEstimada: newDataFim,
       horasRealizadas,

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -247,16 +247,24 @@ export function CalendarioTab({
     [presencas]
   );
 
+  // Tutor não vê pedidos "Aguarda professor".
+  const visibleRequests = useMemo(() => {
+    if (currentUserRole === "tutor") {
+      return requests.filter((r) => r.status !== "pending_professor");
+    }
+    return requests;
+  }, [requests, currentUserRole]);
+
   const requestsByDate = useMemo(() => {
     const map = new Map<string, ScheduleChangeRequest>();
-    for (const r of requests) {
+    for (const r of visibleRequests) {
       const existing = map.get(r.targetDate);
       if (!existing || ["approved", "pending_tutor", "pending_professor"].includes(r.status)) {
         map.set(r.targetDate, r);
       }
     }
     return map;
-  }, [requests]);
+  }, [visibleRequests]);
 
   const requestDateSet = useMemo(() => new Set(requestsByDate.keys()), [requestsByDate]);
 
@@ -274,13 +282,13 @@ export function CalendarioTab({
 
   const pendingRequestsMap = useMemo(() => {
     const map = new Map<string, ScheduleChangeRequest>();
-    for (const r of requests) {
+    for (const r of visibleRequests) {
       if (r.status === "pending_professor" || r.status === "pending_tutor") {
         map.set(r.targetDate, r);
       }
     }
     return map;
-  }, [requests]);
+  }, [visibleRequests]);
 
   function previewIfApproved(iso: string): number | null {
     const req = pendingRequestsMap.get(iso);
@@ -920,24 +928,24 @@ export function CalendarioTab({
       ) : null}
 
       {/* Requests list */}
-      {requests.length > 0 && (
+      {visibleRequests.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-semibold">
               Pedidos de alteração{" "}
               <span className="font-normal text-muted-foreground">
-                ({requests.length})
+                ({visibleRequests.length})
               </span>
             </h3>
             <div className="flex gap-2 text-xs text-muted-foreground">
-              {requests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length > 0 && (
+              {visibleRequests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length > 0 && (
                 <Badge variant="secondary">
-                  {requests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length} pendente{requests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length !== 1 ? "s" : ""}
+                  {visibleRequests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length} pendente{visibleRequests.filter((r) => r.status === "pending_professor" || r.status === "pending_tutor").length !== 1 ? "s" : ""}
                 </Badge>
               )}
             </div>
           </div>
-          {requests.map((req) => (
+          {visibleRequests.map((req) => (
             <ScheduleChangeRequestThread
               key={req.id}
               request={req}

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -42,7 +42,7 @@ import {
 } from "@/lib/estagios/termino-antecipado";
 import type { EstagioRole } from "@/lib/estagios/permissions";
 import { calcTooltipDayInfo } from "@/lib/estagios/calendar-tooltip";
-import { getPortugueseHolidays } from "@/lib/estagios/pt-holidays";
+import { getPortugueseHolidaysMap } from "@/lib/estagios/pt-holidays";
 import { ScheduleChangeRequestModal } from "./schedule-change-request-modal";
 import { ScheduleChangeRequestThread } from "./schedule-change-request-thread";
 import { TerminoAntecipadoConfirmationModal } from "./termino-antecipado-confirmation-modal";
@@ -96,12 +96,14 @@ export function CalendarioTab({
     return new Date(y, m - 1, d);
   };
 
-  const holidaySet = useMemo(() => {
-    if (!dataInicio || !dataFim) return new Set<string>();
+  const holidayMap = useMemo(() => {
+    if (!dataInicio || !dataFim) return new Map<string, string>();
     const startYear = Number(dataInicio.split("-")[0]);
     const endYear = Number(dataFim.split("-")[0]);
-    return getPortugueseHolidays(startYear, endYear);
+    return getPortugueseHolidaysMap(startYear, endYear);
   }, [dataInicio, dataFim]);
+
+  const holidaySet = useMemo(() => new Set(holidayMap.keys()), [holidayMap]);
 
   const holidayDates = useMemo(
     () => [...holidaySet].map((iso) => isoToDate(iso)),
@@ -353,6 +355,7 @@ export function CalendarioTab({
       horasDiarias,
     );
     const isHoliday = holidaySet.has(tooltipDay);
+    const holidayName = holidayMap.get(tooltipDay) ?? "";
     const pendingPrev = previewIfApproved(tooltipDay);
     const pct = totalHoras > 0 ? ((acumuladas / totalHoras) * 100).toFixed(1) : "0.0";
     return {
@@ -362,6 +365,7 @@ export function CalendarioTab({
       previstasDia,
       registadasDia: hasRegistered ? registadasDia : null,
       isHoliday,
+      holidayName,
       pendingPreview: pendingPrev,
       percentagem: pct,
     };
@@ -797,21 +801,24 @@ export function CalendarioTab({
                 className="fixed z-50 rounded-md border bg-popover px-3 py-2 text-xs shadow-md pointer-events-none"
                 style={{ left: tooltipPos.x + 12, top: tooltipPos.y - 10 }}
               >
-                {tooltipData.isHoliday && (
-                  <p className="text-purple-700 font-semibold">Feriado nacional</p>
-                )}
-                <p className="font-medium">{formatIsoPt(tooltipData.data)}</p>
-                <p>{tooltipData.isReal ? "Registadas acumuladas" : "Previstas acumuladas"}: {tooltipData.acumuladas}h</p>
-                {tooltipData.isReal ? (
-                  <p>Registadas no dia: {tooltipData.registadasDia}h</p>
+                {tooltipData.isHoliday ? (
+                  <p className="text-purple-700 font-semibold">{formatIsoPt(tooltipData.data)} · {tooltipData.holidayName}</p>
                 ) : (
-                  <p>Previstas do dia: {tooltipData.previstasDia}h
-                    {tooltipData.pendingPreview !== null && tooltipData.pendingPreview !== tooltipData.previstasDia && (
-                      <span className="text-muted-foreground"> (Se aprovado: {tooltipData.pendingPreview}h)</span>
+                  <>
+                    <p className="font-medium">{formatIsoPt(tooltipData.data)}</p>
+                    <p>{tooltipData.isReal ? "Registadas acumuladas" : "Previstas acumuladas"}: {tooltipData.acumuladas}h</p>
+                    {tooltipData.isReal ? (
+                      <p>Registadas no dia: {tooltipData.registadasDia}h</p>
+                    ) : (
+                      <p>Previstas do dia: {tooltipData.previstasDia}h
+                        {tooltipData.pendingPreview !== null && tooltipData.pendingPreview !== tooltipData.previstasDia && (
+                          <span className="text-muted-foreground"> (Se aprovado: {tooltipData.pendingPreview}h)</span>
+                        )}
+                      </p>
                     )}
-                  </p>
+                    <p>{tooltipData.isReal ? "Percentagem real" : "Percentagem prevista"}: {tooltipData.percentagem}%</p>
+                  </>
                 )}
-                <p>{tooltipData.isReal ? "Percentagem real" : "Percentagem prevista"}: {tooltipData.percentagem}%</p>
               </div>
             )}
           </CardContent>

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/lib/estagios/termino-antecipado";
 import type { EstagioRole } from "@/lib/estagios/permissions";
 import { calcTooltipDayInfo } from "@/lib/estagios/calendar-tooltip";
+import { getPortugueseHolidays } from "@/lib/estagios/pt-holidays";
 import { ScheduleChangeRequestModal } from "./schedule-change-request-modal";
 import { ScheduleChangeRequestThread } from "./schedule-change-request-thread";
 import { TerminoAntecipadoConfirmationModal } from "./termino-antecipado-confirmation-modal";
@@ -89,6 +90,23 @@ export function CalendarioTab({
   );
 
   const weeks = useMemo(() => groupWorkDaysByWeek(workDays), [workDays]);
+
+  const isoToDate = (iso: string) => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return new Date(y, m - 1, d);
+  };
+
+  const holidaySet = useMemo(() => {
+    if (!dataInicio || !dataFim) return new Set<string>();
+    const startYear = Number(dataInicio.split("-")[0]);
+    const endYear = Number(dataFim.split("-")[0]);
+    return getPortugueseHolidays(startYear, endYear);
+  }, [dataInicio, dataFim]);
+
+  const holidayDates = useMemo(
+    () => [...holidaySet].map((iso) => isoToDate(iso)),
+    [holidaySet]
+  );
 
   // Tooltip state
   const [tooltipDay, setTooltipDay] = useState<string | null>(null);
@@ -307,12 +325,12 @@ export function CalendarioTab({
       if (d.iso >= todayIso) continue;
       const p = presencas[d.iso];
       const hours = typeof p?.hoursWorked === "number" ? p.hoursWorked : 0;
-      if (hours < horasDiarias && !requestsByDate.has(d.iso)) {
+      if (horasDiarias - hours > 1 && !requestsByDate.has(d.iso) && !holidaySet.has(d.iso)) {
         set.add(d.iso);
       }
     }
     return set;
-  }, [workDays, todayIso, presencas, horasDiarias, requestsByDate]);
+  }, [workDays, todayIso, presencas, horasDiarias, requestsByDate, holidaySet]);
 
   // Remaining hours
   const totalRealizado = useMemo(() => {
@@ -334,6 +352,7 @@ export function CalendarioTab({
       requestsByDate,
       horasDiarias,
     );
+    const isHoliday = holidaySet.has(tooltipDay);
     const pendingPrev = previewIfApproved(tooltipDay);
     const pct = totalHoras > 0 ? ((acumuladas / totalHoras) * 100).toFixed(1) : "0.0";
     return {
@@ -342,10 +361,11 @@ export function CalendarioTab({
       acumuladas,
       previstasDia,
       registadasDia: hasRegistered ? registadasDia : null,
+      isHoliday,
       pendingPreview: pendingPrev,
       percentagem: pct,
     };
-  }, [tooltipDay, horasDiarias, totalHoras, workDays, presencas, presencaSet, requestsByDate]);
+  }, [tooltipDay, horasDiarias, totalHoras, workDays, presencas, presencaSet, requestsByDate, holidaySet]);
 
   // New eligibility logic for terminoAntecipado
   const eligibilityResult = useMemo(() => {
@@ -371,9 +391,10 @@ export function CalendarioTab({
 
   function hasMissingHours(iso: string): boolean {
     if (iso > todayIso) return false;
+    if (holidaySet.has(iso)) return false;
     const p = presencas[iso];
     const hours = typeof p?.hoursWorked === "number" ? p.hoursWorked : 0;
-    return hours < horasDiarias;
+    return horasDiarias - hours > 1;
   }
 
   const refreshRef = useRef(0);
@@ -443,17 +464,12 @@ export function CalendarioTab({
   }
 
   // Build modifiers for DayPicker
-  const isoToDate = (iso: string) => {
-    const [y, m, d] = iso.split("-").map(Number);
-    return new Date(y, m - 1, d);
-  };
-
   const workedDates = [...presencaSet].map((iso) => {
     if (requestDateSet.has(iso)) return null;
     return isoToDate(iso);
   }).filter(Boolean) as Date[];
   const scheduledDates = [...workDaySet]
-    .filter((iso) => !presencaSet.has(iso) && !missingHoursSet.has(iso) && !requestDateSet.has(iso))
+    .filter((iso) => !presencaSet.has(iso) && !missingHoursSet.has(iso) && !requestDateSet.has(iso) && !holidaySet.has(iso))
     .map((iso) => {
       return isoToDate(iso);
     });
@@ -556,6 +572,7 @@ export function CalendarioTab({
               <LegendItem color="bg-card ring-2 ring-amber-500" label="Pendente" />
               <LegendItem color="bg-card ring-2 ring-emerald-500" label="Aprovado/justificado" />
               <LegendItem color="bg-card ring-2 ring-red-500" label="Rejeitado" />
+              <LegendItem color="bg-purple-200 border-2 border-purple-400" label="Feriado nacional" />
             </div>
             {terminoAntecipado && (
               <div className="flex flex-wrap gap-3 border-t pt-2">
@@ -707,7 +724,7 @@ export function CalendarioTab({
           >
             <style>{`
               .rdp-day--worked .rdp-day_button { background-color: rgb(16 185 129); color: white; border-radius: 9999px; }
-              .rdp-day--scheduled .rdp-day_button { background-color: hsl(var(--primary) / 0.12); border: 1px solid hsl(var(--primary) / 0.5); border-radius: 9999px; }
+              .rdp-day--scheduled .rdp-day_button { background-color: rgb(219 234 254); border: 2px solid rgb(96 165 250); border-radius: 9999px; color: rgb(30 64 175); }
               .rdp-day--missing .rdp-day_button { background-color: rgb(254 243 199); border: 2px solid rgb(251 191 36); border-radius: 9999px; color: rgb(146 64 14); }
               .rdp-day--req-justification .rdp-day_button { background-color: rgb(224 242 254); color: rgb(30 64 175); border-radius: 9999px; }
               .rdp-day--req-future .rdp-day_button { background-color: rgb(255 237 213); color: rgb(154 52 18); border-radius: 9999px; }
@@ -719,6 +736,7 @@ export function CalendarioTab({
               .rdp-day--termino-approved .rdp-day_button { background-color: rgb(204 251 241); border: 2px solid rgb(20 184 166); border-radius: 9999px; color: rgb(15 118 110); }
               .rdp-day--termino-obrigatorio .rdp-day_button { background-color: rgb(255 237 213); border: 2px solid rgb(249 115 22); border-radius: 9999px; color: rgb(154 52 18); }
               .rdp-day--termino-invalidated .rdp-day_button { background-color: rgb(254 202 202); border: 2px solid rgb(239 68 68); border-radius: 9999px; color: rgb(153 27 27); }
+              .rdp-day--holiday .rdp-day_button { background-color: rgb(243 232 255); border: 2px solid rgb(192 132 252); border-radius: 9999px; color: rgb(107 33 168); }
               .rdp-day--can-click .rdp-day_button:hover { cursor: pointer; opacity: 0.8; }
             `}</style>
             <DayPicker
@@ -741,6 +759,7 @@ export function CalendarioTab({
                 terminoApproved: terminoApprovedDates,
                 terminoObrigatorio: terminoObrigatorioDates,
                 terminoInvalidated: terminoInvalidatedDates,
+                holiday: holidayDates,
               }}
               modifiersClassNames={{
                 worked: "rdp-day--worked",
@@ -756,11 +775,12 @@ export function CalendarioTab({
                 terminoApproved: "rdp-day--termino-approved",
                 terminoObrigatorio: "rdp-day--termino-obrigatorio",
                 terminoInvalidated: "rdp-day--termino-invalidated",
+                holiday: "rdp-day--holiday",
               }}
               onDayClick={isAluno ? handleDayClick : undefined}
               onDayMouseEnter={(date: Date, _modifiers: unknown, e: React.MouseEvent) => {
                 const iso = toIsoDate(date);
-                if (!workDaySet.has(iso)) return;
+                if (!workDaySet.has(iso) && !holidaySet.has(iso)) return;
                 if (hoveredIsoRef.current === iso) return;
                 hoveredIsoRef.current = iso;
                 if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
@@ -777,6 +797,9 @@ export function CalendarioTab({
                 className="fixed z-50 rounded-md border bg-popover px-3 py-2 text-xs shadow-md pointer-events-none"
                 style={{ left: tooltipPos.x + 12, top: tooltipPos.y - 10 }}
               >
+                {tooltipData.isHoliday && (
+                  <p className="text-purple-700 font-semibold">Feriado nacional</p>
+                )}
                 <p className="font-medium">{formatIsoPt(tooltipData.data)}</p>
                 <p>{tooltipData.isReal ? "Registadas acumuladas" : "Previstas acumuladas"}: {tooltipData.acumuladas}h</p>
                 {tooltipData.isReal ? (
@@ -890,6 +913,11 @@ export function CalendarioTab({
                       {hours > 0 && !req && (
                         <Badge variant="default" className="bg-emerald-500 hover:bg-emerald-500">
                           Trabalhado
+                        </Badge>
+                      )}
+                      {holidaySet.has(day.iso) && (
+                        <Badge variant="outline" className="border-purple-400 text-purple-700">
+                          Feriado
                         </Badge>
                       )}
                       {terminoAntecipado?.estado === "pendente" && terminoAntecipado.diaDeDispensa === day.iso && (

--- a/components/estagios/estagio-detail-view.tsx
+++ b/components/estagios/estagio-detail-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { doc, getDoc, onSnapshot } from "firebase/firestore";
@@ -107,6 +107,19 @@ export function EstagioDetailView({
       unsub?.();
     };
   }, [estagioId]);
+
+  // Recalcular dataFimEstimada no arranque se houver horas realizadas.
+  const recalcCalled = useRef(false);
+  useEffect(() => {
+    if (!estagio || recalcCalled.current) return;
+    const total = Number(estagio.totalHoras ?? 0);
+    const done = Number(estagio.horasRealizadas ?? 0);
+    if (total > 0 && done > 0 && done < total) {
+      recalcCalled.current = true;
+      fetch(`/api/estagios/${estagio.id}/recalcular-data-fim`, { method: "POST" })
+        .catch(() => { recalcCalled.current = false; });
+    }
+  }, [estagio]);
 
   // Load participants via server API (bypasses rules for tutors from other schools).
   useEffect(() => {

--- a/components/professor/professor-requests-center.tsx
+++ b/components/professor/professor-requests-center.tsx
@@ -8,7 +8,7 @@ import { getAuthRuntime, getDbRuntime } from "@/lib/firebase-runtime";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScheduleChangeRequestsList, type EstagioMetaLite } from "@/components/estagios/schedule-change-requests-list";
-import type { ScheduleChangeRequest, ScheduleChangeRequestStatus, ScheduleChangeRequestType } from "@/lib/estagios/schedule-change-requests";
+import type { ScheduleChangeRequest, ScheduleChangeRequestType } from "@/lib/estagios/schedule-change-requests";
 
 const JUSTIFICATION_TYPES: ScheduleChangeRequestType[] = ["past_absence_justification"];
 const SCHEDULE_TYPES: ScheduleChangeRequestType[] = ["future_absence", "early_termination"];
@@ -68,13 +68,7 @@ export function ProfessorRequestsCenter() {
         requests: ScheduleChangeRequest[];
       };
       if (!json.ok) return;
-      const PENDING_SET = new Set<ScheduleChangeRequestStatus>(["pending_professor", "pending_tutor"]);
-      const out = json.requests.sort((a, b) => {
-        const aP = PENDING_SET.has(a.status) ? 0 : 1;
-        const bP = PENDING_SET.has(b.status) ? 0 : 1;
-        return aP - bP || toMillis(b.createdAt) - toMillis(a.createdAt);
-      });
-      setRequests(out);
+      setRequests(json.requests);
       setLoadingRequests(false);
     } catch (err) {
       console.error("[v0] schedule-change-requests fetch error", err);
@@ -146,12 +140,29 @@ export function ProfessorRequestsCenter() {
   }, [estagiosById, requests]);
 
   const justificationRequests = useMemo(
-    () => requests.filter((r) => JUSTIFICATION_TYPES.includes(r.type)),
+    () => requests
+      .filter((r) => JUSTIFICATION_TYPES.includes(r.type))
+      .sort((a, b) => toMillis(b.targetDate) - toMillis(a.targetDate)),
     [requests]
   );
 
   const scheduleRequests = useMemo(
-    () => requests.filter((r) => SCHEDULE_TYPES.includes(r.type)),
+    () => requests
+      .filter((r) => SCHEDULE_TYPES.includes(r.type))
+      .sort((a, b) => {
+        const d = new Date();
+        const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        const group = (r: ScheduleChangeRequest): number => {
+          if (r.status === "pending_professor") return 0;
+          if (r.status === "pending_tutor" && r.targetDate >= todayStr) return 1;
+          if (r.targetDate >= todayStr) return 2;
+          return 3;
+        };
+        const ga = group(a), gb = group(b);
+        if (ga !== gb) return ga - gb;
+        const diff = toMillis(a.targetDate) - toMillis(b.targetDate);
+        return ga === 3 ? -diff : diff;
+      }),
     [requests]
   );
 

--- a/components/tutor/tutor-requests-center.tsx
+++ b/components/tutor/tutor-requests-center.tsx
@@ -67,13 +67,7 @@ export function TutorRequestsCenter() {
         requests: ScheduleChangeRequest[];
       };
       if (!json.ok) return;
-      const out = json.requests.sort((a, b) => {
-        const aPending = a.status === "pending_tutor" ? 0 : 1;
-        const bPending = b.status === "pending_tutor" ? 0 : 1;
-        if (aPending !== bPending) return aPending - bPending;
-        return toMillis(b.createdAt) - toMillis(a.createdAt);
-      });
-      setRequests(out);
+      setRequests(json.requests);
       setLoadingRequests(false);
     } catch (err) {
       console.error("[v0] schedule-change-requests tutor fetch error", err);
@@ -164,7 +158,21 @@ export function TutorRequestsCenter() {
   }, [estagiosById, requests]);
 
   const scheduleRequests = useMemo(
-    () => requests.filter((r) => SCHEDULE_TYPES.includes(r.type) && r.status !== "pending_professor"),
+    () => requests
+      .filter((r) => SCHEDULE_TYPES.includes(r.type) && r.status !== "pending_professor")
+      .sort((a, b) => {
+        const d = new Date();
+        const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+        const group = (r: ScheduleChangeRequest): number => {
+          if (r.status === "pending_tutor" && r.targetDate >= todayStr) return 0;
+          if (r.targetDate >= todayStr) return 1;
+          return 2;
+        };
+        const ga = group(a), gb = group(b);
+        if (ga !== gb) return ga - gb;
+        const diff = toMillis(a.targetDate) - toMillis(b.targetDate);
+        return ga === 2 ? -diff : diff;
+      }),
     [requests]
   );
 

--- a/components/tutor/tutor-requests-center.tsx
+++ b/components/tutor/tutor-requests-center.tsx
@@ -164,7 +164,7 @@ export function TutorRequestsCenter() {
   }, [estagiosById, requests]);
 
   const scheduleRequests = useMemo(
-    () => requests.filter((r) => SCHEDULE_TYPES.includes(r.type)),
+    () => requests.filter((r) => SCHEDULE_TYPES.includes(r.type) && r.status !== "pending_professor"),
     [requests]
   );
 

--- a/lib/estagios/pt-holidays.ts
+++ b/lib/estagios/pt-holidays.ts
@@ -72,6 +72,32 @@ export function getPortugueseHolidays(yearStart: number, yearEnd: number): Set<s
   return set;
 }
 
+/**
+ * Devolve um Map de data ISO (YYYY-MM-DD) → nome do feriado para todos os
+ * feriados nacionais portugueses entre `yearStart` e `yearEnd` (inclusivo).
+ */
+export function getPortugueseHolidaysMap(yearStart: number, yearEnd: number): Map<string, string> {
+  const map = new Map<string, string>();
+  for (let year = yearStart; year <= yearEnd; year++) {
+    map.set(`${year}-01-01`, "Ano Novo");
+    map.set(`${year}-04-25`, "Dia da Liberdade");
+    map.set(`${year}-05-01`, "Dia do Trabalhador");
+    map.set(`${year}-06-10`, "Dia de Portugal");
+    map.set(`${year}-08-15`, "Assunção de Nossa Senhora");
+    map.set(`${year}-10-05`, "Implantação da República");
+    map.set(`${year}-11-01`, "Dia de Todos-os-Santos");
+    map.set(`${year}-12-01`, "Restauração da Independência");
+    map.set(`${year}-12-08`, "Imaculada Conceição");
+    map.set(`${year}-12-25`, "Natal");
+    const easter = getEasterSunday(year);
+    map.set(toIsoDate(addDays(easter, -47)), "Carnaval");
+    map.set(toIsoDate(addDays(easter, -2)), "Sexta-feira Santa");
+    map.set(toIsoDate(easter), "Domingo de Páscoa");
+    map.set(toIsoDate(addDays(easter, 60)), "Corpo de Deus");
+  }
+  return map;
+}
+
 export function isPortugueseHoliday(dateIso: string, holidays: Set<string>): boolean {
   return holidays.has(dateIso);
 }


### PR DESCRIPTION
Improve Firestore update efficiency by recalculating data only when necessary. Filter out pending requests for tutors in the calendar view and simplify request sorting logic. Integrate Portuguese holidays into the calendar logic and update the UI for better holiday display.