### PR TITLE
fix: expirar comunicados de encerramento + suporte a ausência parcial no horário

### DIFF
--- a/app/api/empresas/route.ts
+++ b/app/api/empresas/route.ts
@@ -81,6 +81,7 @@ export async function GET() {
         localidade: data.localidade as string | undefined,
         distrito: data.distrito as string | undefined,
         logoUrl: data.logoUrl as string | undefined,
+        nif: data.nif as string | undefined,
         ativa: data.ativa as boolean,
         tutorIds: (data.tutorIds as string[]) ?? [],
         empresaGrants: (data.empresaGrants as Record<string, "read" | "write"> | undefined) ?? null,

--- a/app/api/estagios/[id]/recalcular-data-fim/route.ts
+++ b/app/api/estagios/[id]/recalcular-data-fim/route.ts
@@ -66,13 +66,22 @@ export async function POST(
       dom: rawDias.dom ?? false,
     };
 
-    // Buscar schedule_change_requests aprovados
+    // Safeguard: não projetar horas em dias úteis passados não preenchidos
+    const hoje = new Date();
+    const ontem = new Date(hoje);
+    ontem.setDate(ontem.getDate() - 1);
+    const ontemStr = `${ontem.getFullYear()}-${String(ontem.getMonth() + 1).padStart(2, "0")}-${String(ontem.getDate()).padStart(2, "0")}`;
+    const startFromProjecao = ultimaPresenca < ontemStr ? ontemStr : ultimaPresenca;
+
+    // Buscar schedule_change_requests aprovados (incluindo company_closure expirados)
     const scrSnap = await estagioRef.collection("schedule_change_requests").get();
     const ausenciaRequests: AusenciaRequest[] = [];
     const replayRequests: ReplayRequest[] = [];
     scrSnap.forEach((d) => {
       const data = d.data() as Record<string, unknown>;
-      if (data.status === "approved") {
+      const isApproved = data.status === "approved";
+      const isExpiredClosure = data.type === "company_closure" && data.status === "expired";
+      if (isApproved || isExpiredClosure) {
         const req: AusenciaRequest = {
           targetDate: (data.targetDate as string) || d.id,
           absenceType: data.absenceType as string | undefined,
@@ -86,6 +95,27 @@ export async function POST(
       }
     });
 
+    // Expirar comunicados da empresa cuja data já passou
+    const hojeStr = `${hoje.getFullYear()}-${String(hoje.getMonth() + 1).padStart(2, "0")}-${String(hoje.getDate()).padStart(2, "0")}`;
+    const expiredBatch = db.batch();
+    let hasExpired = false;
+    scrSnap.forEach((d) => {
+      const data = d.data() as Record<string, unknown>;
+      if (data.type === "company_closure" && data.status === "approved") {
+        const targetDate = (data.targetDate as string) || d.id;
+        if (targetDate < hojeStr) {
+          expiredBatch.update(d.ref, {
+            status: "expired",
+            updatedAt: FieldValue.serverTimestamp(),
+          });
+          hasExpired = true;
+        }
+      }
+    });
+    if (hasExpired) {
+      await expiredBatch.commit();
+    }
+
     // Recalcular data fim considerando ausências
     const currentDataFim = estagioData.dataFimEstimada as string | undefined;
     const storedAcc = Number(estagioData.horasAusenciaAcumuladas ?? 0);
@@ -94,7 +124,7 @@ export async function POST(
       horasRealizadas,
       horasDiarias,
       diasSemana,
-      startFrom: ultimaPresenca,
+      startFrom: startFromProjecao,
     });
 
     // Data com ausências (walk real)
@@ -103,7 +133,7 @@ export async function POST(
       horasRealizadas,
       horasDiarias,
       diasSemana,
-      startFrom: ultimaPresenca,
+      startFrom: startFromProjecao,
       requests: ausenciaRequests,
     });
 

--- a/components/empresas/empresas-page.tsx
+++ b/components/empresas/empresas-page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 type EmpresaItem = {
   id: string;
   nome: string;
+  nif?: string;
   localidade?: string;
   distrito?: string;
   setor?: string;
@@ -51,6 +52,7 @@ export function EmpresasPage({ basePath }: { basePath: string }) {
     if (!q) return true;
     return (
       e.nome.toLowerCase().includes(q) ||
+      (e.nif || "").toLowerCase().includes(q) ||
       (e.localidade || "").toLowerCase().includes(q) ||
       (e.setor || "").toLowerCase().includes(q)
     );

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -304,7 +304,7 @@ export function CalendarioTab({
   }, [requests, currentUserRole]);
 
   const comunicados = useMemo(
-    () => visibleRequests.filter((r) => r.type === "company_closure"),
+    () => visibleRequests.filter((r) => r.type === "company_closure" && r.status === "approved"),
     [visibleRequests]
   );
 

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -329,7 +329,7 @@ export function CalendarioTab({
   function effectiveHoursForDay(iso: string): number {
     const req = requestsByDate.get(iso);
     if (!req) return horasDiarias;
-    const activeStatuses = ["pending_professor", "pending_tutor", "approved", "acknowledged"];
+    const activeStatuses = ["pending_professor", "pending_tutor", "approved", "acknowledged", "expired"];
     if (!activeStatuses.includes(req.status)) return horasDiarias;
     if (req.absenceType === "total") return 0;
     if (req.absenceType === "partial" && typeof req.hoursAffected === "number") {
@@ -908,7 +908,7 @@ export function CalendarioTab({
                 <Card
                   key={day.iso}
                   className={`transition-colors ${hasNoHours ? "border-amber-400 bg-amber-50/50 dark:border-amber-600 dark:bg-amber-950/30" : ""} ${req ? "border-l-4" : ""} ${
-                    req?.status === "approved" || req?.status === "acknowledged"
+                    req?.status === "approved" || req?.status === "acknowledged" || req?.status === "expired"
                       ? "border-l-emerald-500"
                       : req?.status === "rejected"
                         ? "border-l-red-400"

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -317,7 +317,7 @@ export function CalendarioTab({
     const map = new Map<string, ScheduleChangeRequest>();
     for (const r of visibleRequests) {
       const existing = map.get(r.targetDate);
-      if (!existing || ["approved", "pending_tutor", "pending_professor"].includes(r.status)) {
+      if (!existing || ["approved", "pending_tutor", "pending_professor", "expired"].includes(r.status)) {
         map.set(r.targetDate, r);
       }
     }
@@ -454,7 +454,8 @@ export function CalendarioTab({
       req &&
       (req.status === "pending_professor" ||
         req.status === "pending_tutor" ||
-        req.status === "approved")
+        req.status === "approved" ||
+        req.status === "expired")
     ) {
       return;
     }
@@ -540,7 +541,7 @@ export function CalendarioTab({
       return isoToDate(iso);
     });
   const approvedReqDates = [...requestsByDate.entries()]
-    .filter(([, r]) => r.status === "approved" || r.status === "acknowledged")
+    .filter(([, r]) => r.status === "approved" || r.status === "acknowledged" || r.status === "expired")
     .map(([iso]) => {
       return isoToDate(iso);
     });

--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -99,7 +99,7 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
           const dates = new Set<string>();
           snap.forEach((d) => {
             const req = d.data() as ScheduleChangeRequest;
-            if ((req.type === "future_absence" || req.type === "company_closure") && req.status === "approved") {
+            if ((req.type === "future_absence" || req.type === "company_closure") && (req.status === "approved" || req.status === "expired")) {
               if (req.targetDate) dates.add(req.targetDate);
             }
           });

--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -86,6 +86,7 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
     originalEnd && originalEnd > dataFim ? originalEnd : dataFim;
 
   const [fechoExcludedDates, setFechoExcludedDates] = useState<Set<string>>(new Set());
+  const [partialAbsenceDates, setPartialAbsenceDates] = useState<Map<string, number>>(new Map());
 
   useEffect(() => {
     let unsub: (() => void) | undefined;
@@ -96,14 +97,25 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
       unsub = onSnapshot(
         collection(db, "estagios", estagioId, "schedule_change_requests"),
         (snap) => {
-          const dates = new Set<string>();
+          const fullExclusion = new Set<string>();
+          const partial = new Map<string, number>();
           snap.forEach((d) => {
             const req = d.data() as ScheduleChangeRequest;
-            if ((req.type === "future_absence" || req.type === "company_closure") && (req.status === "approved" || req.status === "expired")) {
-              if (req.targetDate) dates.add(req.targetDate);
+            if (req.status !== "approved" && req.status !== "expired") return;
+            if (!req.targetDate) return;
+            if (req.type === "company_closure") {
+              fullExclusion.add(req.targetDate);
+            } else if (req.type === "future_absence") {
+              if (req.absenceType === "partial") {
+                partial.set(req.targetDate, req.hoursAffected);
+              } else {
+                fullExclusion.add(req.targetDate);
+              }
             }
           });
-          setFechoExcludedDates(dates);
+          for (const date of fullExclusion) partial.delete(date);
+          setFechoExcludedDates(fullExclusion);
+          setPartialAbsenceDates(partial);
         },
         (err) => {
           if ((err as { code?: string }).code !== "permission-denied") {
@@ -116,7 +128,7 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
       cancelled = true;
       unsub?.();
     };
-  }, [estagioId]);
+  }, [estagioId, setPartialAbsenceDates]);
 
   const workDays = useMemo(
     () => listWorkDays(dataInicio, effectiveDataFim, dias, fechoExcludedDates),
@@ -483,6 +495,8 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
                     const draft = getDraft(day);
                     const persisted = presencas[day.iso];
                     const isFuture = day.iso > todayIso;
+                    const affectedHours = partialAbsenceDates.get(day.iso);
+                    const expected = affectedHours != null ? Math.max(0, horasDiarias - affectedHours) : horasDiarias;
                     const error = errors[day.iso];
                     const isSaving = saving === day.iso;
                     const isSavedFlash = savedFlash === day.iso;
@@ -497,7 +511,7 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
                     return (
                       <div
                         key={day.iso}
-                        className="grid grid-cols-1 gap-2 rounded-md border bg-card px-3 py-3 sm:grid-cols-[180px_1fr_1fr_auto] sm:items-center"
+                        className={`grid grid-cols-1 gap-2 rounded-md border bg-card px-3 py-3 sm:grid-cols-[180px_1fr_1fr_auto] sm:items-center${partialAbsenceDates.has(day.iso) ? " border-l-amber-500" : ""}`}
                       >
                         <div className="flex items-center gap-2">
                           <Calendar className="h-4 w-4 text-muted-foreground" />
@@ -507,9 +521,12 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
                             </p>
                             {isFuture ? (
                               <p className="text-[11px] text-muted-foreground">Dia futuro</p>
-                            ) : horasDiarias > 0 ? (
+                            ) : expected > 0 ? (
                               <p className="text-[11px] text-muted-foreground">
-                                Previstas: {horasDiarias}h
+                                Previstas: {expected}h
+                                {partialAbsenceDates.has(day.iso) && (
+                                  <span className="ml-1 text-amber-600">(ausência parcial)</span>
+                                )}
                               </p>
                             ) : null}
                           </div>

--- a/components/tutor/tutor-requests-center.tsx
+++ b/components/tutor/tutor-requests-center.tsx
@@ -161,7 +161,7 @@ export function TutorRequestsCenter() {
   const comunicados = useMemo(() => {
     const map = new Map<string, ScheduleChangeRequest>();
     for (const r of requests) {
-      if (r.type !== "company_closure") continue;
+      if (r.type !== "company_closure" || r.status === "expired") continue;
       const key = `${r.targetDate}|${r.reason}`;
       if (!map.has(key)) map.set(key, r);
     }

--- a/lib/estagios/calendar-tooltip.ts
+++ b/lib/estagios/calendar-tooltip.ts
@@ -11,7 +11,7 @@ type RequestInfo = {
   hoursAffected?: number;
 };
 
-const ACTIVE_STATUSES = ["pending_professor", "pending_tutor", "approved", "acknowledged"];
+const ACTIVE_STATUSES = ["pending_professor", "pending_tutor", "approved", "acknowledged", "expired"];
 
 function dayEffectiveHours(
   iso: string,

--- a/lib/estagios/schedule-change-requests.ts
+++ b/lib/estagios/schedule-change-requests.ts
@@ -21,7 +21,8 @@ export type ScheduleChangeRequestStatus =
   | "approved"
   | "rejected"
   | "cancelled"
-  | "acknowledged";
+  | "acknowledged"
+  | "expired";
 
 export type RequestComment = {
   authorId: string;
@@ -268,6 +269,8 @@ export function labelForStatus(status: ScheduleChangeRequestStatus, requestType?
       return "Cancelado";
     case "acknowledged":
       return "Tomado conhecimento";
+    case "expired":
+      return "Expirado";
   }
 }
 

--- a/tests/actions/calendar-tooltip.test.ts
+++ b/tests/actions/calendar-tooltip.test.ts
@@ -173,6 +173,15 @@ describe("absences via requestsByDate", () => {
     });
     expect(r.acumuladas).toBe(15);
   });
+
+  it("expired total absence treated as 0h", () => {
+    const r = fixt("2026-05-14", {
+      workDays: [{ iso: "2026-05-12" }, { iso: "2026-05-13" }, { iso: "2026-05-14" }],
+      requestsByDate: reqs([["2026-05-13", { status: "expired", absenceType: "total", hoursAffected: 0 }]]),
+      horasDiarias: 7.5,
+    });
+    expect(r.acumuladas).toBe(15);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -204,6 +213,13 @@ describe("previstasDia", () => {
       requestsByDate: reqs([["2026-05-13", { status: "rejected", absenceType: "total" }]]),
     });
     expect(r.previstasDia).toBe(7.5);
+  });
+
+  it("returns 0 for expired total absence", () => {
+    const r = fixt("2026-05-13", {
+      requestsByDate: reqs([["2026-05-13", { status: "expired", absenceType: "total", hoursAffected: 0 }]]),
+    });
+    expect(r.previstasDia).toBe(0);
   });
 });
 

--- a/tests/actions/date-calc.test.ts
+++ b/tests/actions/date-calc.test.ts
@@ -312,6 +312,35 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
         realFim: 403,
       },
     },
+
+    // ════════════════════════════════════════════════════════════════════
+    // CASO PÓS-PATCH: 260h realizadas, 4 ausências (sem closure Jun 5,
+    // que está antes do startFromProjecao). startFrom=Jun 8 para
+    // simular o safeguard que cap ultimaPresenca a ontem.
+    //   Walk: Jun 9 a Jul 7 = 20 dias, acum 392→400 (exactas).
+    // ════════════════════════════════════════════════════════════════════
+    {
+      name: "PÓS-PATCH: 260h, 4 ausências, startFrom=Jun 8 → Jul 7 com 400h exactas",
+      totalHoras: 400, horasRealizadas: 260, horasDiarias: 8, diasSemana: segSex, startFrom: "2026-06-08",
+      requests: [
+        { targetDate: "2026-06-16", isPartial: true, hoursAffected: 4 },
+        { targetDate: "2026-06-23", isPartial: true, hoursAffected: 4 },
+        { targetDate: "2026-06-24", isPartial: false, hoursAffected: 0 },
+        { targetDate: "2026-06-30", isPartial: true, hoursAffected: 4 },
+      ],
+      preAcc: 7,
+      guardCurrentDate: null,
+      want: {
+        rawDate: "2026-07-06",
+        diasUteis: 19,
+        excessPushes: 1,
+        correctAcc: 3,
+        realDate: "2026-07-07",
+        realDays: 20,
+        realInicio: 392,
+        realFim: 400,
+      },
+    },
   ];
 
   for (const c of cases) {


### PR DESCRIPTION
## O que muda
### Expiração de comunicados (fix)
- Comunicados de encerramento (`company_closure`) com `targetDate` passada são marcados como `"expired"` durante o recálculo da data fim
- Dias expirados ficam invisíveis na vista de cartões mas continuam visíveis no calendário (com orla verde)
- Tooltip do calendário trata dias expirados como 0h acumuladas
- Bloqueio de registo de presenças em dias de encerramento expirados
### Ausência parcial (feat)
- Dias com `future_absence` de tipo `partial` já não são removidos da lista de trabalho no separador Horário
- Mostram `expected = horasDiarias - hoursAffected` na label "Previstas"
- Bordo lateral âmbar e tag `(ausência parcial)` como indicador visual
- Input de horas permanece editável nestes dias
### Recalculo (fix)
- `startFromProjecao` capped a `max(ultimaPresenca, ontem)` para evitar projetar horas em dias passados não preenchidos
- `ausenciaRequests` no recalculo inclui `status === "expired"` para company_closure
## Ficheiros alterados (10, +120/-21)
| Ficheiro | Mudança |
|---|---|
| `route.ts` recalcular-data-fim | Expira comunicados, filtro ausencias, cap projeção |
| `calendario-tab.tsx` | Orla verde, clique bloqueado em expirados |
| `horario-tab.tsx` | Snapshot separa partial/total, expected ajustado, bordo âmbar |
| `calendar-tooltip.ts` | `expired` em ACTIVE_STATUSES |
| `schedule-change-requests.ts` | Label "Expirado" |
| `calendar-tooltip.test.ts` | Testes com expired |
| `date-calc.test.ts` | Teste pós-patch 260h + 4 ausências |
Closes # (pendente)