### PR TITLE
fix(calendario): simplifica preenchimentos e corrige cálculo de data fim

### DIFF
--- a/app/api/chat/get-profiles/route.ts
+++ b/app/api/chat/get-profiles/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { getFirebaseAdminAuth, getFirebaseAdminDb } from "@/lib/firebase-admin"
+import { SESSION_COOKIE_NAME } from "@/lib/auth/session"
+
+export const runtime = "nodejs"
+
+export async function POST(request: Request) {
+  try {
+    const jar = await cookies()
+    const sessionCookie = jar.get(SESSION_COOKIE_NAME)?.value
+    if (!sessionCookie) {
+      return NextResponse.json({ error: "Sessão inexistente" }, { status: 401 })
+    }
+
+    const auth = getFirebaseAdminAuth()
+    await auth.verifySessionCookie(sessionCookie, true)
+    const db = getFirebaseAdminDb()
+
+    const { userIds } = (await request.json()) as { userIds?: string[] }
+    if (!userIds || !Array.isArray(userIds) || userIds.length === 0) {
+      return NextResponse.json({ profiles: [] })
+    }
+
+    const profiles = await Promise.all(
+      userIds.map(async (uid) => {
+        try {
+          const snap = await db.collection("users").doc(uid).get()
+          if (!snap.exists) return null
+          const data = snap.data() as {
+            nome?: string
+            name?: string
+            email?: string
+            photoURL?: string
+            role?: string
+            schoolId?: string
+            escolaId?: string
+          }
+
+          const chatRole =
+            data.role === "professor"
+              ? "teacher"
+              : data.role === "tutor"
+                ? "tutor"
+                : data.role === "admin_escolar"
+                  ? "admin"
+                  : data.role === "encarregado"
+                    ? "encarregado"
+                    : "student"
+
+          return {
+            uid,
+            name: data.nome || data.name || "Utilizador",
+            email: data.email || "",
+            photoURL: data.photoURL || "",
+            role: chatRole,
+            orgId: data.schoolId || data.escolaId || null,
+          }
+        } catch {
+          return null
+        }
+      })
+    )
+
+    return NextResponse.json({ profiles: profiles.filter(Boolean) })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/chat/resolve-user/route.ts
+++ b/app/api/chat/resolve-user/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getFirebaseAdminAuth, getFirebaseAdminDb } from "@/lib/firebase-admin";
+import { SESSION_COOKIE_NAME } from "@/lib/auth/session";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    const jar = await cookies();
+    const sessionCookie = jar.get(SESSION_COOKIE_NAME)?.value;
+    if (!sessionCookie) {
+      return NextResponse.json({ error: "Sessão inexistente" }, { status: 401 });
+    }
+
+    const auth = getFirebaseAdminAuth();
+    const decoded = await auth.verifySessionCookie(sessionCookie, true);
+    const db = getFirebaseAdminDb();
+
+    const { email } = (await request.json()) as { email?: string };
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ user: null });
+    }
+
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) {
+      return NextResponse.json({ user: null });
+    }
+
+    const snap = await db
+      .collection("users")
+      .where("email", "==", normalized)
+      .limit(1)
+      .get();
+
+    if (snap.empty) {
+      return NextResponse.json({ user: null });
+    }
+
+    const docSnap = snap.docs[0];
+    const data = docSnap.data() as {
+      nome?: string;
+      email?: string;
+      photoURL?: string;
+      role?: string;
+      estado?: string;
+      schoolId?: string;
+      escolaId?: string;
+    };
+
+    if ((data.estado || "").toLowerCase() === "removido") {
+      return NextResponse.json({ user: null });
+    }
+
+    const chatRole =
+      data.role === "professor"
+        ? "teacher"
+        : data.role === "tutor"
+          ? "tutor"
+          : data.role === "admin_escolar"
+            ? "admin"
+            : "student";
+
+    return NextResponse.json({
+      user: {
+        uid: docSnap.id,
+        name: data.nome || "Utilizador",
+        email: data.email || normalized,
+        photoURL: data.photoURL || "",
+        role: chatRole,
+        orgId: data.schoolId || data.escolaId || null,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/chat/search-members/route.ts
+++ b/app/api/chat/search-members/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { getFirebaseAdminAuth, getFirebaseAdminDb } from "@/lib/firebase-admin"
+import { SESSION_COOKIE_NAME } from "@/lib/auth/session"
+
+export const runtime = "nodejs"
+
+export async function POST(request: Request) {
+  try {
+    const jar = await cookies()
+    const sessionCookie = jar.get(SESSION_COOKIE_NAME)?.value
+    if (!sessionCookie) {
+      return NextResponse.json({ error: "Sessão inexistente" }, { status: 401 })
+    }
+
+    const auth = getFirebaseAdminAuth()
+    await auth.verifySessionCookie(sessionCookie, true)
+    const db = getFirebaseAdminDb()
+
+    const { orgId, queryText, currentUserId, currentUserRole } = (await request.json()) as {
+      orgId?: string | null
+      queryText?: string
+      currentUserId?: string
+      currentUserRole?: string
+    }
+
+    if (!orgId || !currentUserId) {
+      return NextResponse.json({ members: [] })
+    }
+
+    const term = (queryText || "").trim().toLowerCase()
+
+    const [schoolIdSnap, escolaIdSnap] = await Promise.all([
+      db.collection("users").where("schoolId", "==", orgId).get(),
+      db.collection("users").where("escolaId", "==", orgId).get(),
+    ])
+
+    const seen = new Set<string>()
+    const results: Array<{
+      uid: string
+      name: string
+      email: string
+      photoURL: string
+      role: string
+      orgId: string | null
+    }> = []
+
+    const addDoc = (snap: FirebaseFirestore.QueryDocumentSnapshot) => {
+      if (seen.has(snap.id)) return
+      seen.add(snap.id)
+
+      const data = snap.data() as {
+        nome?: string
+        name?: string
+        email?: string
+        photoURL?: string
+        role?: string
+        estado?: string
+        schoolId?: string
+        escolaId?: string
+      }
+
+      if (snap.id === currentUserId) return
+      if ((data.estado || "").toLowerCase() !== "ativo") return
+
+      const profileOrgId = data.schoolId || data.escolaId || null
+      if (profileOrgId !== orgId) return
+
+      const role = toChatRoleAdmin(data.role)
+      if (currentUserRole === "tutor") {
+        // tutors see all same-school active users
+      } else if (currentUserRole === "student") {
+        if (role === "encarregado" && snap.id !== currentUserId) return
+        if (!["student", "teacher", "admin", "tutor"].includes(role)) return
+      }
+
+      const name = data.nome || data.name || "Utilizador"
+      if (term && !name.toLowerCase().includes(term) && !(data.email || "").toLowerCase().includes(term)) return
+
+      results.push({
+        uid: snap.id,
+        name,
+        email: data.email || "",
+        photoURL: data.photoURL || "",
+        role,
+        orgId: profileOrgId,
+      })
+    }
+
+    schoolIdSnap.forEach(addDoc)
+    escolaIdSnap.forEach(addDoc)
+
+    results.sort((a, b) => a.name.localeCompare(b.name, "pt-PT"))
+
+    return NextResponse.json({ members: results })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+function toChatRoleAdmin(role: string | undefined): string {
+  switch ((role || "").toLowerCase()) {
+    case "aluno":
+      return "student"
+    case "professor":
+      return "teacher"
+    case "admin_escolar":
+      return "admin"
+    case "tutor":
+      return "tutor"
+    case "encarregado":
+      return "encarregado"
+    default:
+      return "student"
+  }
+}

--- a/components/chat/internal-chat-hub.tsx
+++ b/components/chat/internal-chat-hub.tsx
@@ -93,7 +93,7 @@ type PendingMessage = {
 };
 
 const PAGE_SIZE = 30;
-const MESSAGE_SEQUENCE_WINDOW_MS = 60 * 60 * 1000;
+const MESSAGE_SEQUENCE_WINDOW_MS = 5 * 60 * 1000;
 
 function initials(name: string): string {
   const chunks = name.trim().split(/\s+/).slice(0, 2);
@@ -1556,10 +1556,12 @@ export function InternalChatHub() {
                             </>
                           ) : null}
 
-                          <div className="shrink-0">
-                            <span>{formatMessageDateTime(message.createdAt)}</span>
-                            {editedMeta ? <span className="ml-2 italic">{editedMeta}</span> : null}
-                          </div>
+                          {!sameSenderAsPrev ? (
+                            <div className="shrink-0">
+                              <span>{formatMessageDateTime(message.createdAt)}</span>
+                              {editedMeta ? <span className="ml-2 italic">{editedMeta}</span> : null}
+                            </div>
+                          ) : null}
                         </div>
 
                         <div className={[

--- a/components/chat/internal-chat-hub.tsx
+++ b/components/chat/internal-chat-hub.tsx
@@ -729,34 +729,18 @@ export function InternalChatHub() {
     const normalized = email.trim().toLowerCase();
     if (!normalized || !isValidEmail(normalized)) return null;
 
-    const fsDb = await getDbRuntime();
-    const [byEmail] = await Promise.all([
-      getDocs(query(collection(fsDb, "users"), where("email", "==", normalized), limit(1))),
-    ]);
-
-    const docSnap = byEmail.docs[0] || null;
-    if (!docSnap) return null;
-
-    const data = docSnap.data() as {
-      nome?: string;
-      email?: string;
-      photoURL?: string;
-      role?: string;
-      estado?: string;
-      schoolId?: string;
-      escolaId?: string;
-    };
-
-    if ((data.estado || "").toLowerCase() === "removido") return null;
-
-    return {
-      uid: docSnap.id,
-      name: data.nome || "Utilizador",
-      email: data.email || normalized,
-      photoURL: data.photoURL || "",
-      role: data.role === "professor" ? "teacher" : data.role === "tutor" ? "tutor" : data.role === "admin_escolar" ? "admin" : "student",
-      orgId: data.schoolId || data.escolaId || null,
-    };
+    try {
+      const res = await fetch("/api/chat/resolve-user", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: normalized }),
+      });
+      if (!res.ok) return null;
+      const json = (await res.json()) as { user?: ChatUserProfile | null };
+      return json.user || null;
+    } catch {
+      return null;
+    }
   }, []);
 
   const handleCreateConversation = useCallback(async () => {

--- a/components/chat/internal-chat-hub.tsx
+++ b/components/chat/internal-chat-hub.tsx
@@ -1363,7 +1363,7 @@ export function InternalChatHub() {
                       type="button"
                       onClick={() => setSelectedConversationId(conv.id)}
                       className={[
-                        "w-full rounded-lg border px-3 py-2 text-left transition-colors",
+                        "w-full rounded-lg border px-3 py-2 pr-8 text-left transition-colors",
                         selected ? "border-primary/50 bg-primary/10" : "border-transparent hover:bg-muted",
                       ].join(" ")}
                     >

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -378,19 +378,37 @@ export function CalendarioTab({
     return horasDiarias;
   }
 
-  // Missing hours days (past workdays without registered hours or below expected)
-  const missingHoursSet = useMemo(() => {
+  // Days with hours within/above tolerance (green fill)
+  const workedOkSet = useMemo(() => {
     const set = new Set<string>();
     for (const d of workDays) {
-      if (d.iso >= todayIso) continue;
+      if (holidaySet.has(d.iso)) continue;
       const p = presencas[d.iso];
       const hours = typeof p?.hoursWorked === "number" ? p.hoursWorked : 0;
-      if (horasDiarias - hours > 1 && !requestsByDate.has(d.iso) && !holidaySet.has(d.iso)) {
+      if (hours <= 0) continue;
+      const expected = effectiveHoursForDay(d.iso);
+      if (hours >= expected - 1) {
         set.add(d.iso);
       }
     }
     return set;
-  }, [workDays, todayIso, presencas, horasDiarias, requestsByDate, holidaySet]);
+  }, [workDays, presencas, requestsByDate, horasDiarias, holidaySet]);
+
+  // Past days below tolerance (yellow fill)
+  const missingSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const d of workDays) {
+      if (d.iso >= todayIso) continue;
+      if (holidaySet.has(d.iso)) continue;
+      const p = presencas[d.iso];
+      const hours = typeof p?.hoursWorked === "number" ? p.hoursWorked : 0;
+      const expected = effectiveHoursForDay(d.iso);
+      if (hours < expected - 1) {
+        set.add(d.iso);
+      }
+    }
+    return set;
+  }, [workDays, todayIso, presencas, requestsByDate, horasDiarias, holidaySet]);
 
   // Remaining hours
   const totalRealizado = useMemo(() => {
@@ -537,50 +555,27 @@ export function CalendarioTab({
   }
 
   // Build modifiers for DayPicker
-  const workedDates = [...presencaSet].map((iso) => {
-    if (requestDateSet.has(iso)) return null;
-    return isoToDate(iso);
-  }).filter(Boolean) as Date[];
+  const workedOkDates = [...workedOkSet].map(isoToDate);
   const scheduledDates = [...workDaySet]
-    .filter((iso) => !presencaSet.has(iso) && !missingHoursSet.has(iso) && !requestDateSet.has(iso) && !holidaySet.has(iso))
-    .map((iso) => isoToDate(iso));
-  const holidayScheduled = [...holidayWorkSet]
-    .filter((iso) => !presencaSet.has(iso))
+    .filter((iso) => {
+      if (iso <= todayIso) return false;
+      if (presencaSet.has(iso)) return false;
+      if (requestDateSet.has(iso)) return false;
+      if (holidaySet.has(iso)) return false;
+      return true;
+    })
     .map(isoToDate);
-  const missingDates = [...missingHoursSet].map((iso) => {
-    return isoToDate(iso);
-  });
-  const requestTypeDates = (() => {
-    const justification: Date[] = [];
-    const futureAbsence: Date[] = [];
-    const earlyTermination: Date[] = [];
-    for (const [iso, req] of requestsByDate.entries()) {
-      const date = isoToDate(iso);
-      if (req.type === "past_absence_justification") {
-        justification.push(date);
-      } else if (req.type === "future_absence") {
-        futureAbsence.push(date);
-      } else if (req.type === "early_termination") {
-        earlyTermination.push(date);
-      }
-    }
-    return { justification, futureAbsence, earlyTermination };
-  })();
+  const missingDates = [...missingSet].map(isoToDate);
   const pendingDates = [...requestsByDate.entries()]
     .filter(([, r]) => r.status === "pending_professor" || r.status === "pending_tutor")
-    .map(([iso]) => {
-      return isoToDate(iso);
-    });
+    .map(([iso]) => isoToDate(iso));
   const approvedReqDates = [...requestsByDate.entries()]
     .filter(([, r]) => r.status === "approved" || r.status === "acknowledged" || r.status === "expired")
-    .map(([iso]) => {
-      return isoToDate(iso);
-    });
+    .map(([iso]) => isoToDate(iso));
   const rejectedReqDates = [...requestsByDate.entries()]
     .filter(([, r]) => r.status === "rejected")
-    .map(([iso]) => {
-      return isoToDate(iso);
-    });
+    .map(([iso]) => isoToDate(iso));
+  const todayDates = [isoToDate(todayIso)];
 
   // TerminoAntecipado date modifiers
   const terminoPendingDates = useMemo(() => {
@@ -635,14 +630,12 @@ export function CalendarioTab({
           {/* Legend */}
           <div className="space-y-2 text-xs">
             <div className="flex flex-wrap gap-3">
-              <LegendItem color="bg-emerald-500" label="Dia trabalhado" />
-              <LegendItem color="bg-primary/20 border border-primary" label="Dia previsto" />
-              <LegendItem color="bg-amber-100 border-2 border-amber-400" label="Horas em falta" />
+              <LegendItem color="bg-emerald-500" label="Dia dentro do esperado" />
+              <LegendItem color="bg-blue-500" label="Dia atual" />
+              <LegendItem color="bg-yellow-200" label="Horas abaixo do esperado" />
             </div>
             <div className="flex flex-wrap gap-3">
-              <LegendItem color="bg-sky-100 border border-sky-400" label="Justificação de falta" />
-              <LegendItem color="bg-orange-100 border border-orange-400" label="Falta futura" />
-              <LegendItem color="bg-teal-100 border border-teal-400" label="Término antecipado" />
+              <LegendItem color="bg-card ring-2 ring-blue-400" label="Dia previsto" />
               <LegendItem color="bg-card ring-2 ring-amber-500" label="Pendente" />
               <LegendItem color="bg-card ring-2 ring-emerald-500" label="Aprovado/justificado" />
               <LegendItem color="bg-card ring-2 ring-red-500" label="Rejeitado" />
@@ -650,9 +643,9 @@ export function CalendarioTab({
             </div>
             {terminoAntecipado && (
               <div className="flex flex-wrap gap-3 border-t pt-2">
-                <LegendItem color="bg-yellow-200 border-2 border-yellow-500" label="Dispensa pendente" />
-                <LegendItem color="bg-teal-200 border-2 border-teal-500" label="Dispensa aprovada" />
-                <LegendItem color="bg-orange-200 border-2 border-orange-500" label="Dia obrigatório (dispensa)" />
+                <LegendItem color="bg-card ring-2 ring-yellow-500" label="Dispensa pendente" />
+                <LegendItem color="bg-card ring-2 ring-teal-500" label="Dispensa aprovada" />
+                <LegendItem color="bg-card ring-2 ring-orange-500" label="Dia obrigatório (dispensa)" />
               </div>
             )}
           </div>
@@ -797,19 +790,17 @@ export function CalendarioTab({
             }}
           >
             <style>{`
-              .rdp-day--worked .rdp-day_button { background-color: rgb(16 185 129); color: white; border-radius: 9999px; }
-              .rdp-day--scheduled .rdp-day_button { background-color: rgb(219 234 254); border: 2px solid rgb(96 165 250); border-radius: 9999px; color: rgb(30 64 175); }
-              .rdp-day--missing .rdp-day_button { background-color: rgb(254 243 199); border: 2px solid rgb(251 191 36); border-radius: 9999px; color: rgb(146 64 14); }
-              .rdp-day--req-justification .rdp-day_button { background-color: rgb(224 242 254); color: rgb(30 64 175); border-radius: 9999px; }
-              .rdp-day--req-future .rdp-day_button { background-color: rgb(255 237 213); color: rgb(154 52 18); border-radius: 9999px; }
-              .rdp-day--req-termination .rdp-day_button { background-color: rgb(204 251 241); color: rgb(15 118 110); border-radius: 9999px; }
+              .rdp-day--scheduled .rdp-day_button { box-shadow: 0 0 0 2px rgb(96 165 250); border-radius: 9999px; }
               .rdp-day--status-pending .rdp-day_button { box-shadow: 0 0 0 2px rgb(245 158 11); }
               .rdp-day--status-approved .rdp-day_button { box-shadow: 0 0 0 2px rgb(16 185 129); }
               .rdp-day--status-rejected .rdp-day_button { box-shadow: 0 0 0 2px rgb(239 68 68); }
-              .rdp-day--termino-pending .rdp-day_button { background-color: rgb(254 240 138); border: 2px solid rgb(234 179 8); border-radius: 9999px; color: rgb(113 63 18); }
-              .rdp-day--termino-approved .rdp-day_button { background-color: rgb(204 251 241); border: 2px solid rgb(20 184 166); border-radius: 9999px; color: rgb(15 118 110); }
-              .rdp-day--termino-obrigatorio .rdp-day_button { background-color: rgb(255 237 213); border: 2px solid rgb(249 115 22); border-radius: 9999px; color: rgb(154 52 18); }
-              .rdp-day--termino-invalidated .rdp-day_button { background-color: rgb(254 202 202); border: 2px solid rgb(239 68 68); border-radius: 9999px; color: rgb(153 27 27); }
+              .rdp-day--termino-pending .rdp-day_button { box-shadow: 0 0 0 2px rgb(234 179 8); border-radius: 9999px; }
+              .rdp-day--termino-approved .rdp-day_button { box-shadow: 0 0 0 2px rgb(20 184 166); border-radius: 9999px; }
+              .rdp-day--termino-obrigatorio .rdp-day_button { box-shadow: 0 0 0 2px rgb(249 115 22); border-radius: 9999px; }
+              .rdp-day--termino-invalidated .rdp-day_button { box-shadow: 0 0 0 2px rgb(239 68 68); border-radius: 9999px; }
+              .rdp-day--today .rdp-day_button { background-color: rgb(59 130 246); color: white; border-radius: 9999px; }
+              .rdp-day--worked-ok .rdp-day_button { background-color: rgb(16 185 129); color: white; border-radius: 9999px; }
+              .rdp-day--missing .rdp-day_button { background-color: rgb(254 240 138); color: rgb(113 63 18); border-radius: 9999px; }
               .rdp-day--holiday .rdp-day_button { background-color: rgb(243 232 255); border: 2px solid rgb(192 132 252); border-radius: 9999px; color: rgb(107 33 168); }
               .rdp-day--can-click .rdp-day_button:hover { cursor: pointer; opacity: 0.8; }
             `}</style>
@@ -820,12 +811,10 @@ export function CalendarioTab({
               startMonth={startDate}
               endMonth={endDate}
               modifiers={{
-                worked: workedDates,
-                scheduled: [...scheduledDates, ...holidayScheduled],
+                today: todayDates,
+                workedOk: workedOkDates,
+                scheduled: scheduledDates,
                 missing: missingDates,
-                requestJustification: requestTypeDates.justification,
-                requestFutureAbsence: requestTypeDates.futureAbsence,
-                requestEarlyTermination: requestTypeDates.earlyTermination,
                 statusPending: pendingDates,
                 statusApproved: approvedReqDates,
                 statusRejected: rejectedReqDates,
@@ -836,12 +825,10 @@ export function CalendarioTab({
                 holiday: holidayDatesFiltered,
               }}
               modifiersClassNames={{
-                worked: "rdp-day--worked",
+                today: "rdp-day--today",
+                workedOk: "rdp-day--worked-ok",
                 scheduled: "rdp-day--scheduled",
                 missing: "rdp-day--missing",
-                requestJustification: "rdp-day--req-justification",
-                requestFutureAbsence: "rdp-day--req-future",
-                requestEarlyTermination: "rdp-day--req-termination",
                 statusPending: "rdp-day--status-pending",
                 statusApproved: "rdp-day--status-approved",
                 statusRejected: "rdp-day--status-rejected",
@@ -934,7 +921,7 @@ export function CalendarioTab({
               const hours = typeof presenca?.hoursWorked === "number" ? presenca.hoursWorked : 0;
               const notes = presenca?.notes ?? "";
               const isPast = day.iso <= todayIso;
-              const isMissing = missingHoursSet.has(day.iso);
+              const isMissing = missingSet.has(day.iso);
               const req = requestsByDate.get(day.iso);
               const hasNoHours = !isPast ? false : hours <= 0 && !req;
 

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -335,7 +335,11 @@ export function CalendarioTab({
     if (req.absenceType === "partial" && typeof req.hoursAffected === "number") {
       return Math.max(0, horasDiarias - req.hoursAffected);
     }
-    return horasDiarias;
+    // Fallback for requests missing absenceType: infer from hoursAffected
+    if (typeof req.hoursAffected === "number" && req.hoursAffected > 0) {
+      return Math.max(0, horasDiarias - req.hoursAffected);
+    }
+    return 0;
   }
 
   const pendingRequestsMap = useMemo(() => {
@@ -848,6 +852,8 @@ export function CalendarioTab({
                     <p>{tooltipData.isReal ? "Registadas acumuladas" : "Previstas acumuladas"}: {tooltipData.acumuladas}h</p>
                     {tooltipData.isReal ? (
                       <p>Registadas no dia: {tooltipData.registadasDia}h</p>
+                    ) : tooltipData.previstasDia === 0 && !tooltipData.isHoliday ? (
+                      <p>Registadas no dia: 0h</p>
                     ) : (
                       <p>Previstas do dia: {tooltipData.previstasDia}h
                         {tooltipData.pendingPreview !== null && tooltipData.pendingPreview !== tooltipData.previstasDia && (

--- a/components/estagios/calendario-tab.tsx
+++ b/components/estagios/calendario-tab.tsx
@@ -51,6 +51,7 @@ import { ScheduleChangeRequestModal } from "./schedule-change-request-modal";
 import { ScheduleChangeRequestThread } from "./schedule-change-request-thread";
 import { ComunicadoCard } from "./comunicado-card";
 import { TerminoAntecipadoConfirmationModal } from "./termino-antecipado-confirmation-modal";
+import { HolidayWorkDialog } from "./holiday-work-dialog";
 
 type Props = {
   estagioId: string;
@@ -64,6 +65,7 @@ type PresencaDoc = {
   date: string;
   hoursWorked: number;
   notes?: string;
+  isHolidayWork?: boolean;
 };
 
 type ViewMode = "month" | "week";
@@ -285,6 +287,20 @@ export function CalendarioTab({
   const [eligibility, setEligibility] = useState<EligibilityResult | null>(null);
   const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
 
+  // Holiday work dialog
+  const [holidayWorkDialogOpen, setHolidayWorkDialogOpen] = useState(false);
+  const [holidayWorkDate, setHolidayWorkDate] = useState<string>("");
+
+  const holidayWorkSet = useMemo(
+    () => new Set(Object.values(presencas).filter((p) => p.isHolidayWork).map((p) => p.date)),
+    [presencas]
+  );
+
+  const holidayDatesFiltered = useMemo(
+    () => holidayDates.filter((d) => !holidayWorkSet.has(toIsoDate(d))),
+    [holidayDates, holidayWorkSet]
+  );
+
   const presencaSet = useMemo(
     () =>
       new Set(
@@ -396,7 +412,7 @@ export function CalendarioTab({
       requestsByDate,
       horasDiarias,
     );
-    const isHoliday = holidaySet.has(tooltipDay);
+    const isHoliday = holidaySet.has(tooltipDay) && !holidayWorkSet.has(tooltipDay);
     const holidayName = holidayMap.get(tooltipDay) ?? "";
     const pendingPrev = previewIfApproved(tooltipDay);
     const pct = totalHoras > 0 ? ((acumuladas / totalHoras) * 100).toFixed(1) : "0.0";
@@ -411,7 +427,7 @@ export function CalendarioTab({
       pendingPreview: pendingPrev,
       percentagem: pct,
     };
-  }, [tooltipDay, horasDiarias, totalHoras, workDays, presencas, presencaSet, requestsByDate, holidaySet]);
+  }, [tooltipDay, horasDiarias, totalHoras, workDays, presencas, presencaSet, requestsByDate, holidaySet, holidayWorkSet]);
 
   // New eligibility logic for terminoAntecipado
   const eligibilityResult = useMemo(() => {
@@ -449,8 +465,18 @@ export function CalendarioTab({
   }, []);
 
   function handleDayClick(date: Date) {
-    if (!isAluno) return;
     const iso = toIsoDate(date);
+
+    // Handle holiday clicks — offer to work on the holiday (any user)
+    if (holidaySet.has(iso)) {
+      if (holidayWorkSet.has(iso)) return;
+      setHolidayWorkDate(iso);
+      setHolidayWorkDialogOpen(true);
+      return;
+    }
+
+    if (!isAluno) return;
+
     if (!workDaySet.has(iso)) return;
 
     const req = requestsByDate.get(iso);
@@ -517,9 +543,10 @@ export function CalendarioTab({
   }).filter(Boolean) as Date[];
   const scheduledDates = [...workDaySet]
     .filter((iso) => !presencaSet.has(iso) && !missingHoursSet.has(iso) && !requestDateSet.has(iso) && !holidaySet.has(iso))
-    .map((iso) => {
-      return isoToDate(iso);
-    });
+    .map((iso) => isoToDate(iso));
+  const holidayScheduled = [...holidayWorkSet]
+    .filter((iso) => !presencaSet.has(iso))
+    .map(isoToDate);
   const missingDates = [...missingHoursSet].map((iso) => {
     return isoToDate(iso);
   });
@@ -794,7 +821,7 @@ export function CalendarioTab({
               endMonth={endDate}
               modifiers={{
                 worked: workedDates,
-                scheduled: scheduledDates,
+                scheduled: [...scheduledDates, ...holidayScheduled],
                 missing: missingDates,
                 requestJustification: requestTypeDates.justification,
                 requestFutureAbsence: requestTypeDates.futureAbsence,
@@ -806,7 +833,7 @@ export function CalendarioTab({
                 terminoApproved: terminoApprovedDates,
                 terminoObrigatorio: terminoObrigatorioDates,
                 terminoInvalidated: terminoInvalidatedDates,
-                holiday: holidayDates,
+                holiday: holidayDatesFiltered,
               }}
               modifiersClassNames={{
                 worked: "rdp-day--worked",
@@ -824,7 +851,7 @@ export function CalendarioTab({
                 terminoInvalidated: "rdp-day--termino-invalidated",
                 holiday: "rdp-day--holiday",
               }}
-              onDayClick={isAluno ? handleDayClick : undefined}
+              onDayClick={handleDayClick}
               onDayMouseEnter={(date: Date, _modifiers: unknown, e: React.MouseEvent) => {
                 const iso = toIsoDate(date);
                 if (!workDaySet.has(iso) && !holidaySet.has(iso)) return;
@@ -1071,6 +1098,19 @@ export function CalendarioTab({
         canRequestEarlyTermination={eligibleForEarlyTermination}
         onCreated={handleUpdated}
         defaultType={modalDefaultType}
+      />
+
+      {/* Holiday work dialog */}
+      <HolidayWorkDialog
+        open={holidayWorkDialogOpen}
+        onClose={() => setHolidayWorkDialogOpen(false)}
+        estagioId={estagioId}
+        targetDate={holidayWorkDate}
+        isPast={holidayWorkDate <= todayIso}
+        horasDiarias={horasDiarias}
+        currentUserId={currentUserId}
+        currentUserRole={currentUserRole}
+        onCreated={handleUpdated}
       />
 
       {/* TerminoAntecipado confirmation modal */}

--- a/components/estagios/holiday-work-dialog.tsx
+++ b/components/estagios/holiday-work-dialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { getDbRuntime } from "@/lib/firebase-runtime";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { formatIsoPt } from "@/lib/estagios/workdays";
+import { Loader2 } from "lucide-react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  estagioId: string;
+  targetDate: string;
+  isPast: boolean;
+  horasDiarias: number;
+  currentUserId: string;
+  currentUserRole: string;
+  onCreated: () => void;
+};
+
+export function HolidayWorkDialog({
+  open,
+  onClose,
+  estagioId,
+  targetDate,
+  isPast,
+  horasDiarias,
+  currentUserId,
+  currentUserRole,
+  onCreated,
+}: Props) {
+  const [hours, setHours] = useState<string>(String(horasDiarias));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    setError(null);
+
+    if (isPast) {
+      const v = Number(hours.replace(",", "."));
+      if (!Number.isFinite(v) || v < 0 || v > 12) {
+        setError("Indica um número de horas válido (0–12).");
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      const db = await getDbRuntime();
+      const ref = doc(db, "estagios", estagioId, "presencas", targetDate);
+      const payload: Record<string, unknown> = {
+        date: targetDate,
+        hoursWorked: isPast ? Math.round(Number(hours.replace(",", ".")) * 100) / 100 : 0,
+        isHolidayWork: true,
+        updatedAt: serverTimestamp(),
+        updatedBy: currentUserId,
+        updatedByRole: currentUserRole,
+      };
+      if (!isPast) {
+        payload.hoursScheduled = horasDiarias || undefined;
+      }
+      Object.keys(payload).forEach((k) => {
+        if (payload[k] === undefined) delete payload[k];
+      });
+      await setDoc(ref, payload, { merge: true });
+
+      // Side effects for past saves
+      if (isPast) {
+        fetch(`/api/estagios/${estagioId}/termino-antecipado/invalidar`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            dataPresenca: targetDate,
+            horasTrabalhadas: Number(hours),
+            horasPrevistasNoDia: horasDiarias || 0,
+          }),
+        }).catch(() => {});
+
+        fetch(`/api/estagios/${estagioId}/recalcular-data-fim`, {
+          method: "POST",
+        }).catch(() => {});
+      }
+
+      onCreated();
+      handleClose();
+    } catch (err) {
+      console.error("[holiday-work] save error", err);
+      setError("Não foi possível guardar. Tenta novamente.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleClose() {
+    setHours(String(horasDiarias));
+    setError(null);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>
+            {isPast ? "Trabalhaste neste feriado?" : "Vais trabalhar neste feriado?"}
+          </DialogTitle>
+          <DialogDescription>
+            {formatIsoPt(targetDate)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {isPast ? (
+            <div className="space-y-2">
+              <Label htmlFor="holiday-hours">Número de horas trabalhadas</Label>
+              <Input
+                id="holiday-hours"
+                type="number"
+                min={0}
+                max={12}
+                step={0.25}
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+                placeholder="Ex: 8"
+                disabled={saving}
+              />
+              {error && (
+                <p className="text-xs text-destructive">{error}</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              O dia será marcado como dia de trabalho e ficará disponível na aba
+              Horário para registares as horas quando trabalhares.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={handleClose} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            {isPast ? "Guardar" : "Sim, vou trabalhar"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -131,6 +131,8 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
     };
   }, [estagioId, setPartialAbsenceDates]);
 
+  const [presencas, setPresencas] = useState<Record<string, PresencaDoc>>({});
+
   const holidayWorkSet = useMemo(
     () => new Set(Object.values(presencas).filter((p) => p.isHolidayWork).map((p) => p.date)),
     [presencas]
@@ -141,8 +143,6 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
     [dataInicio, effectiveDataFim, dias, fechoExcludedDates, holidayWorkSet]
   );
   const weeks = useMemo(() => groupWorkDaysByWeek(workDays), [workDays]);
-
-  const [presencas, setPresencas] = useState<Record<string, PresencaDoc>>({});
   const [loading, setLoading] = useState(true);
   const [drafts, setDrafts] = useState<Record<string, { hours: string; notes: string }>>({});
   const [saving, setSaving] = useState<string | null>(null);

--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -47,6 +47,7 @@ type PresencaDoc = {
   updatedAt?: unknown;
   updatedBy?: string;
   updatedByRole?: string;
+  isHolidayWork?: boolean;
 };
 
 const MAX_HOURS_PER_DAY = 12;
@@ -130,9 +131,14 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
     };
   }, [estagioId, setPartialAbsenceDates]);
 
+  const holidayWorkSet = useMemo(
+    () => new Set(Object.values(presencas).filter((p) => p.isHolidayWork).map((p) => p.date)),
+    [presencas]
+  );
+
   const workDays = useMemo(
-    () => listWorkDays(dataInicio, effectiveDataFim, dias, fechoExcludedDates),
-    [dataInicio, effectiveDataFim, dias, fechoExcludedDates]
+    () => listWorkDays(dataInicio, effectiveDataFim, dias, fechoExcludedDates, holidayWorkSet),
+    [dataInicio, effectiveDataFim, dias, fechoExcludedDates, holidayWorkSet]
   );
   const weeks = useMemo(() => groupWorkDaysByWeek(workDays), [workDays]);
 

--- a/components/estagios/horario-tab.tsx
+++ b/components/estagios/horario-tab.tsx
@@ -149,6 +149,7 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [savedFlash, setSavedFlash] = useState<string | null>(null);
   const [collapsedWeeks, setCollapsedWeeks] = useState<Record<string, boolean>>({});
+  const prevPresencasKeyRef = useRef("");
 
   // Subscribe to all presencas of this estagio.
   useEffect(() => {
@@ -166,7 +167,11 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
             const data = d.data() as PresencaDoc;
             out[d.id] = data;
           });
-          setPresencas(out);
+          const key = JSON.stringify(out);
+          if (key !== prevPresencasKeyRef.current) {
+            prevPresencasKeyRef.current = key;
+            setPresencas(out);
+          }
           setLoading(false);
         },
         (err) => {
@@ -189,13 +194,16 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
   const todayIso = toIsoDate(new Date());
 
   useEffect(() => {
-    if (weeks.length === 0 || Object.keys(collapsedWeeks).length > 0) return;
-    const init: Record<string, boolean> = {};
-    for (const w of weeks) {
-      if (isPastWeek(w, todayIso)) init[w.weekId] = true;
-    }
-    setCollapsedWeeks(init);
-  }, [weeks, todayIso, collapsedWeeks]);
+    if (weeks.length === 0) return;
+    setCollapsedWeeks((prev) => {
+      if (Object.keys(prev).length > 0) return prev;
+      const init: Record<string, boolean> = {};
+      for (const w of weeks) {
+        if (isPastWeek(w, todayIso)) init[w.weekId] = true;
+      }
+      return init;
+    });
+  }, [weeks, todayIso]);
 
   const sortedWeeks = useMemo(
     () => sortWeeksHorario(weeks, todayIso),
@@ -213,9 +221,12 @@ export function HorarioTab({ estagioId, estagio, currentUserId, currentUserRole 
   const restante = Math.max(0, totalHoras - totalRealizado);
   const pct = totalHoras > 0 ? Math.round((totalRealizado / totalHoras) * 100) : 0;
 
-  const diasRegistados = Object.values(presencas).filter(
-    (p) => typeof p.hoursWorked === "number" && p.hoursWorked > 0
-  ).length;
+  const diasRegistados = useMemo(
+    () => Object.values(presencas).filter(
+      (p) => typeof p.hoursWorked === "number" && p.hoursWorked > 0
+    ).length,
+    [presencas]
+  );
 
   // Recalcular dataFimEstimada quando todas as presenças registadas mas ainda faltam horas.
   useEffect(() => {

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -4,7 +4,8 @@ import type React from "react"
 
 import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Sidebar } from "@/components/layout/sidebar"
+import { useSidebarCollapsed } from "@/lib/use-sidebar-collapsed"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -59,6 +60,7 @@ type AuthState = {
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { collapsed, toggle: toggleSidebar } = useSidebarCollapsed()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const [state, setState] = useState<AuthState>({
     loading: true,
@@ -165,80 +167,49 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   return (
     <div className="min-h-screen bg-background">
       {isLoggingOut ? <LogoutOverlay /> : null}
-      {/* Mobile sidebar */}
-      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-64 p-0">
-          <div className="flex h-full flex-col">
-            <div className="flex h-16 items-center gap-2 px-6 border-b border-border">
-              <GraduationCap className="h-6 w-6 text-primary" />
-              <span className="font-semibold text-foreground">InternLink</span>
-            </div>
-            <nav className="flex-1 space-y-1 p-4">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={[
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActiveRoute(item.href)
-                      ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                  ].join(" ")}
-                  aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                  onClick={() => setSidebarOpen(false)}
-                >
-                  <item.icon className="h-4 w-4" />
-                  <span>{item.name}</span>
-                  {item.href === "/dashboard/chat" && (
-                    <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                  )}
-                </Link>
-              ))}
-            </nav>
-          </div>
-        </SheetContent>
-      </Sheet>
-
-      {/* Desktop sidebar */}
-      <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-64 lg:flex-col">
-        <div className="flex grow flex-col gap-y-5 overflow-y-auto border-r border-border bg-card px-6">
-          <div className="flex h-16 shrink-0 items-center gap-2">
-            <GraduationCap className="h-6 w-6 text-primary" />
-            <span className="font-semibold text-card-foreground">InternLink</span>
-          </div>
-          <nav className="flex flex-1 flex-col">
-            <ul role="list" className="flex flex-1 flex-col gap-y-7">
-              <li>
-                <ul role="list" className="-mx-2 space-y-1">
-                  {navigation.map((item) => (
-                    <li key={item.name}>
-                      <Link
-                        href={item.href}
-                        className={[
-                          "flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
-                          isActiveRoute(item.href)
-                            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                        ].join(" ")}
-                        aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                      >
-                        <item.icon className="h-4 w-4 shrink-0" />
-                        <span>{item.name}</span>
-                        {item.href === "/dashboard/chat" && (
-                          <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                        )}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            </ul>
-          </nav>
+      <Sidebar
+        collapsed={collapsed}
+        onToggle={toggleSidebar}
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+      >
+        <div className={`flex h-16 shrink-0 items-center transition-all duration-300 ${collapsed ? "justify-center" : "gap-x-3"}`}>
+          <GraduationCap className="h-7 w-7 text-primary" />
+          {!collapsed && <span className="text-sm font-semibold">InternLink</span>}
         </div>
-      </div>
+        <nav className="flex flex-1 flex-col">
+          <ul role="list" className="flex flex-1 flex-col gap-y-7">
+            <li>
+              <ul role="list" className="-mx-2 space-y-1">
+                {navigation.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      href={item.href}
+                      className={[
+                        "flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
+                        collapsed ? "justify-center" : "",
+                        isActiveRoute(item.href)
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                      ].join(" ")}
+                      aria-current={isActiveRoute(item.href) ? "page" : undefined}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {!collapsed && <span>{item.name}</span>}
+                      {!collapsed && item.href === "/dashboard/chat" && (
+                        <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </Sidebar>
 
       {/* Main content */}
-      <div className="lg:pl-64">
+      <div className={`transition-all duration-300 ${collapsed ? "lg:pl-[72px]" : "lg:pl-72"}`}>
         {/* Top bar */}
         <div className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-border bg-card px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
           <Button variant="ghost" size="sm" className="lg:hidden" onClick={() => setSidebarOpen(true)}>

--- a/components/layout/encarregado-layout.tsx
+++ b/components/layout/encarregado-layout.tsx
@@ -14,7 +14,8 @@ import { NotificationsInbox } from "@/components/chat/notifications-inbox";
 import { useChatNotifications } from "@/lib/chat/use-chat-notifications";
 import { ChatNavUnreadBadge } from "@/components/chat/chat-nav-unread-badge";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sidebar } from "@/components/layout/sidebar";
+import { useSidebarCollapsed } from "@/lib/use-sidebar-collapsed";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -53,6 +54,7 @@ type AuthState = {
 
 export function EncarregadoLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { collapsed, toggle: toggleSidebar } = useSidebarCollapsed();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [state, setState] = useState<AuthState>({
     loading: true,
@@ -159,87 +161,54 @@ export function EncarregadoLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background">
       {isLoggingOut ? <LogoutOverlay /> : null}
-
-      {/* Mobile sidebar */}
-      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-72 p-0">
-          <div className="flex h-full flex-col bg-card">
-            <div className="flex h-16 items-center gap-2 px-6 border-b border-border">
-              <GraduationCap className="h-6 w-6 text-primary" />
-              <div>
-                <p className="text-sm font-semibold">InternLink</p>
-                <p className="text-xs text-muted-foreground">Encarregado de Educação</p>
-              </div>
-            </div>
-            <nav className="flex-1 space-y-1 p-4">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={[
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActiveRoute(item.href)
-                      ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                  ].join(" ")}
-                  aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                  onClick={() => setSidebarOpen(false)}
-                >
-                  <item.icon className="h-4 w-4" />
-                  <span>{item.name}</span>
-                  {item.href === "/encarregado/chat" && (
-                    <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                  )}
-                </Link>
-              ))}
-            </nav>
-          </div>
-        </SheetContent>
-      </Sheet>
-
-      {/* Desktop sidebar */}
-      <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
-        <div className="flex grow flex-col gap-y-6 overflow-y-auto border-r border-border bg-card px-6">
-          <div className="flex h-16 items-center gap-2">
-            <GraduationCap className="h-6 w-6 text-primary" />
-            <div>
+      <Sidebar
+        collapsed={collapsed}
+        onToggle={toggleSidebar}
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+      >
+        <div className={`flex h-16 shrink-0 items-center transition-all duration-300 ${collapsed ? "justify-center" : "gap-x-3"}`}>
+          <GraduationCap className="h-7 w-7 text-primary" />
+          {!collapsed && (
+            <div className="leading-tight">
               <p className="text-sm font-semibold">InternLink</p>
               <p className="text-xs text-muted-foreground">Encarregado de Educação</p>
             </div>
-          </div>
-          <nav className="flex flex-1 flex-col">
-            <ul role="list" className="flex flex-1 flex-col gap-y-7">
-              <li>
-                <ul role="list" className="-mx-2 space-y-1">
-                  {navigation.map((item) => (
-                    <li key={item.name}>
-                      <Link
-                        href={item.href}
-                        className={[
-                          "flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
-                          isActiveRoute(item.href)
-                            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                        ].join(" ")}
-                        aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                      >
-                        <item.icon className="h-4 w-4 shrink-0" />
-                        <span>{item.name}</span>
-                        {item.href === "/encarregado/chat" && (
-                          <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                        )}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            </ul>
-          </nav>
+          )}
         </div>
-      </div>
+        <nav className="flex flex-1 flex-col">
+          <ul role="list" className="flex flex-1 flex-col gap-y-7">
+            <li>
+              <ul role="list" className="-mx-2 space-y-1">
+                {navigation.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      href={item.href}
+                      className={[
+                        "flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
+                        collapsed ? "justify-center" : "",
+                        isActiveRoute(item.href)
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                      ].join(" ")}
+                      aria-current={isActiveRoute(item.href) ? "page" : undefined}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {!collapsed && <span>{item.name}</span>}
+                      {!collapsed && item.href === "/encarregado/chat" && (
+                        <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </Sidebar>
 
       {/* Main content */}
-      <div className="lg:pl-72">
+      <div className={`transition-all duration-300 ${collapsed ? "lg:pl-[72px]" : "lg:pl-72"}`}>
         {/* Top bar */}
         <div className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-border bg-card px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
           <Button variant="ghost" size="sm" className="lg:hidden" onClick={() => setSidebarOpen(true)}>

--- a/components/layout/professor-layout.tsx
+++ b/components/layout/professor-layout.tsx
@@ -13,7 +13,8 @@ import { NotificationsInbox, type InboxNotification } from "@/components/chat/no
 import { useChatNotifications } from "@/lib/chat/use-chat-notifications";
 import { useEstagioNotifications, type EstagioNotification } from "@/lib/notifications/use-estagio-notifications";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sidebar } from "@/components/layout/sidebar";
+import { useSidebarCollapsed } from "@/lib/use-sidebar-collapsed";
 import { TRANSITION_PORTAL_MS } from "@/components/layout/access-validation-overlay";
 import { LogoutOverlay } from "@/components/layout/logout-overlay";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -79,6 +80,7 @@ function buildNotificationHref(notification: EstagioNotification): string | null
 
 export function ProfessorLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { collapsed, toggle: toggleSidebar } = useSidebarCollapsed();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [state, setState] = useState<AuthState>({
     loading: true,
@@ -244,86 +246,54 @@ export function ProfessorLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background">
       {isLoggingOut ? <LogoutOverlay /> : null}
-      {/* Mobile sidebar */}
-      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-72 p-0">
-          <div className="flex h-full flex-col bg-card">
-            <div className="flex h-16 items-center gap-2 px-6 border-b border-border">
-              <GraduationCap className="h-6 w-6 text-primary" />
-              <div>
-                <p className="text-sm font-semibold">InternLink</p>
-                <p className="text-xs text-muted-foreground">Professor</p>
-              </div>
-            </div>
-            <nav className="flex-1 space-y-1 p-4">
-              {filteredNavigation.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={[
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActiveRoute(item.href)
-                      ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                  ].join(" ")}
-                  aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                  onClick={() => setSidebarOpen(false)}
-                >
-                  <item.icon className="h-4 w-4" />
-                  <span>{item.name}</span>
-                  {item.href === "/professor/chat" && (
-                    <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                  )}
-                </Link>
-              ))}
-            </nav>
-          </div>
-        </SheetContent>
-      </Sheet>
-
-      {/* Desktop sidebar */}
-      <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
-        <div className="flex grow flex-col gap-y-6 overflow-y-auto border-r border-border bg-card px-6">
-          <div className="flex h-16 items-center gap-2">
-            <GraduationCap className="h-6 w-6 text-primary" />
-            <div>
+      <Sidebar
+        collapsed={collapsed}
+        onToggle={toggleSidebar}
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+      >
+        <div className={`flex h-16 shrink-0 items-center transition-all duration-300 ${collapsed ? "justify-center" : "gap-x-3"}`}>
+          <GraduationCap className="h-7 w-7 text-primary" />
+          {!collapsed && (
+            <div className="leading-tight">
               <p className="text-sm font-semibold">InternLink</p>
               <p className="text-xs text-muted-foreground">Professor</p>
             </div>
-          </div>
-          <nav className="flex flex-1 flex-col">
-            <ul role="list" className="flex flex-1 flex-col gap-y-7">
-              <li>
-                <ul role="list" className="-mx-2 space-y-1">
-                  {filteredNavigation.map((item) => (
-                    <li key={item.name}>
-                      <Link
-                        href={item.href}
-                        className={[
-                          "flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
-                          isActiveRoute(item.href)
-                            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                        ].join(" ")}
-                        aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                      >
-                        <item.icon className="h-4 w-4 shrink-0" />
-                        <span>{item.name}</span>
-                        {item.href === "/professor/chat" && (
-                          <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                        )}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            </ul>
-          </nav>
+          )}
         </div>
-      </div>
+        <nav className="flex flex-1 flex-col">
+          <ul role="list" className="flex flex-1 flex-col gap-y-7">
+            <li>
+              <ul role="list" className="-mx-2 space-y-1">
+                {filteredNavigation.map((item) => (
+                  <li key={item.name}>
+                    <Link
+                      href={item.href}
+                      className={[
+                        "flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
+                        collapsed ? "justify-center" : "",
+                        isActiveRoute(item.href)
+                          ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                      ].join(" ")}
+                      aria-current={isActiveRoute(item.href) ? "page" : undefined}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {!collapsed && <span>{item.name}</span>}
+                      {!collapsed && item.href === "/professor/chat" && (
+                        <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
+                      )}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </Sidebar>
 
       {/* Main content */}
-      <div className="lg:pl-72">
+      <div className={`transition-all duration-300 ${collapsed ? "lg:pl-[72px]" : "lg:pl-72"}`}>
         {/* Top bar */}
         <div className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-border bg-card px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
           <Button variant="ghost" size="sm" className="lg:hidden" onClick={() => setSidebarOpen(true)}>

--- a/components/layout/school-admin-layout.tsx
+++ b/components/layout/school-admin-layout.tsx
@@ -15,7 +15,8 @@ import { NotificationsInbox } from "@/components/chat/notifications-inbox";
 import { useChatNotifications } from "@/lib/chat/use-chat-notifications";
 import { SchoolAdminApprovalsBadge } from "@/components/school-admin/school-admin-approvals-badge";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sidebar } from "@/components/layout/sidebar";
+import { useSidebarCollapsed } from "@/lib/use-sidebar-collapsed";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { CheckSquare, Folder, GraduationCap, History, Home, Info, LogOut, Menu, MessageSquare, Users, Building2 } from "lucide-react";
 
@@ -41,6 +42,7 @@ type AuthState = {
 
 export function SchoolAdminLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { collapsed, toggle: toggleSidebar } = useSidebarCollapsed();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [state, setState] = useState<AuthState>({
     loading: true,
@@ -141,89 +143,56 @@ export function SchoolAdminLayout({ children }: { children: React.ReactNode }) {
     >
       <div className="min-h-screen bg-muted/20">
         {isLoggingOut ? <LogoutOverlay /> : null}
-        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-          <SheetContent side="left" className="w-72 p-0">
-            <div className="flex h-full flex-col bg-card">
-              <div className="flex h-16 items-center gap-2 px-6 border-b border-border">
-                <GraduationCap className="h-6 w-6 text-primary" />
-                <div>
-                  <p className="text-sm font-semibold">InternLink</p>
-                  <p className="text-xs text-muted-foreground">Admin Escolar</p>
-                </div>
-              </div>
-              <nav className="flex-1 space-y-1 p-4">
-                {navigation.map((item) => (
-                  <Link
-                    key={item.name}
-                    href={item.href}
-                    className={[
-                      "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                      isActiveRoute(item.href)
-                        ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                        : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                    ].join(" ")}
-                    aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                    onClick={() => setSidebarOpen(false)}
-                  >
-                    <item.icon className="h-4 w-4" />
-                    <span>{item.name}</span>
-                    {item.href === "/school-admin/chat" && (
-                      <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                    )}
-                    {item.href === "/school-admin/aprovacoes" && (
-                      <SchoolAdminApprovalsBadge schoolId={state.schoolId} isActive={isActiveRoute(item.href)} />
-                    )}
-                  </Link>
-                ))}
-              </nav>
-            </div>
-          </SheetContent>
-        </Sheet>
-
-        <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
-          <div className="flex grow flex-col gap-y-6 overflow-y-auto border-r border-border bg-card px-6">
-            <div className="flex h-16 items-center gap-2">
-              <GraduationCap className="h-6 w-6 text-primary" />
-              <div>
+        <Sidebar
+          collapsed={collapsed}
+          onToggle={toggleSidebar}
+          sidebarOpen={sidebarOpen}
+          setSidebarOpen={setSidebarOpen}
+        >
+          <div className={`flex h-16 shrink-0 items-center transition-all duration-300 ${collapsed ? "justify-center" : "gap-x-3"}`}>
+            <GraduationCap className="h-7 w-7 text-primary" />
+            {!collapsed && (
+              <div className="leading-tight">
                 <p className="text-sm font-semibold">InternLink</p>
                 <p className="text-xs text-muted-foreground">Admin Escolar</p>
               </div>
-            </div>
-            <nav className="flex flex-1 flex-col">
-              <ul role="list" className="flex flex-1 flex-col gap-y-7">
-                <li>
-                  <ul role="list" className="-mx-2 space-y-1">
-                    {navigation.map((item) => (
-                      <li key={item.name}>
-                        <Link
-                          href={item.href}
-                          className={[
-                            "flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
-                            isActiveRoute(item.href)
-                              ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                              : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-                          ].join(" ")}
-                          aria-current={isActiveRoute(item.href) ? "page" : undefined}
-                        >
-                          <item.icon className="h-4 w-4 shrink-0" />
-                          <span>{item.name}</span>
-                          {item.href === "/school-admin/chat" && (
-                            <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
-                          )}
-                          {item.href === "/school-admin/aprovacoes" && (
-                            <SchoolAdminApprovalsBadge schoolId={state.schoolId} isActive={isActiveRoute(item.href)} />
-                          )}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              </ul>
-            </nav>
+            )}
           </div>
-        </div>
+          <nav className="flex flex-1 flex-col">
+            <ul role="list" className="flex flex-1 flex-col gap-y-7">
+              <li>
+                <ul role="list" className="-mx-2 space-y-1">
+                  {navigation.map((item) => (
+                    <li key={item.name}>
+                      <Link
+                        href={item.href}
+                        className={[
+                          "flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 transition-colors",
+                          collapsed ? "justify-center" : "",
+                          isActiveRoute(item.href)
+                            ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                        ].join(" ")}
+                        aria-current={isActiveRoute(item.href) ? "page" : undefined}
+                      >
+                        <item.icon className="h-4 w-4 shrink-0" />
+                        {!collapsed && <span>{item.name}</span>}
+                        {!collapsed && item.href === "/school-admin/chat" && (
+                          <ChatNavUnreadBadge userId={state.userId} isActive={isActiveRoute(item.href)} />
+                        )}
+                        {!collapsed && item.href === "/school-admin/aprovacoes" && (
+                          <SchoolAdminApprovalsBadge schoolId={state.schoolId} isActive={isActiveRoute(item.href)} />
+                        )}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            </ul>
+          </nav>
+        </Sidebar>
 
-        <div className="lg:pl-72">
+        <div className={`transition-all duration-300 ${collapsed ? "lg:pl-[72px]" : "lg:pl-72"}`}>
           <div className="sticky top-0 z-40 flex h-16 items-center gap-x-4 border-b border-border bg-background/95 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
             <Button variant="ghost" size="sm" className="lg:hidden" onClick={() => setSidebarOpen(true)}>
               <Menu className="h-5 w-5" />

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type React from "react";
+import { PanelLeftClose } from "lucide-react";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+
+type SidebarProps = {
+  children: React.ReactNode;
+  collapsed: boolean;
+  onToggle: () => void;
+  sidebarOpen: boolean;
+  setSidebarOpen: (open: boolean) => void;
+};
+
+export function Sidebar({ children, collapsed, onToggle, sidebarOpen, setSidebarOpen }: SidebarProps) {
+  return (
+    <>
+      <div
+        className={[
+          "hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col transition-all duration-300",
+          collapsed ? "lg:w-[72px]" : "lg:w-72",
+        ].join(" ")}
+      >
+        <div
+          className={[
+            "flex grow flex-col gap-y-6 overflow-y-auto border-r border-border bg-card pb-4 transition-all duration-300",
+            collapsed ? "px-3" : "px-6",
+          ].join(" ")}
+        >
+          {children}
+          <button
+            type="button"
+            onClick={onToggle}
+            className={[
+              "flex items-center gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors",
+              collapsed ? "justify-center" : "",
+            ].join(" ")}
+            title={collapsed ? "Expandir sidebar" : "Recolher sidebar"}
+          >
+            <PanelLeftClose
+              className={[
+                "h-4 w-4 shrink-0 transition-transform duration-300",
+                collapsed ? "rotate-180" : "",
+              ].join(" ")}
+            />
+            {!collapsed && <span>Recolher</span>}
+          </button>
+        </div>
+      </div>
+
+      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+        <SheetContent side="left" className="w-72 p-0">
+          <div className="flex h-full flex-col bg-card px-6 pb-4 overflow-y-auto">
+            {children}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/components/tutor/tutor-school-internships.tsx
+++ b/components/tutor/tutor-school-internships.tsx
@@ -9,7 +9,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { ArrowLeft, ArrowRight, FileText, FileUp, User } from "lucide-react";
+import { ArrowLeft, ArrowRight, FileText, FileUp, Search, User } from "lucide-react";
+import { Input } from "@/components/ui/input";
 
 type Estagio = {
   id: string;
@@ -18,6 +19,8 @@ type Estagio = {
   alunoEmail: string;
   empresa: string;
   estado: string;
+  professorId: string;
+  professorNome: string;
 };
 
 type SchoolData = {
@@ -41,8 +44,21 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
     bannerFocusY: 50,
   });
   const [estagios, setEstagios] = useState<Estagio[]>([]);
+  const [search, setSearch] = useState("");
 
   const schoolLabel = useMemo(() => school.shortName || school.name, [school]);
+
+  const filteredEstagios = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return estagios;
+    return estagios.filter(
+      (e) =>
+        e.professorNome.toLowerCase().includes(term) ||
+        e.alunoNome.toLowerCase().includes(term) ||
+        e.empresa.toLowerCase().includes(term) ||
+        e.titulo.toLowerCase().includes(term)
+    );
+  }, [estagios, search]);
 
   useEffect(() => {
     let unsubscribe = () => {};
@@ -102,6 +118,8 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
               alunoEmail?: string;
               empresa?: string;
               estado?: string;
+              professorId?: string;
+              professorNome?: string;
             };
             map.set(docSnap.id, {
               id: docSnap.id,
@@ -110,6 +128,8 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
               alunoEmail: data.alunoEmail || "",
               empresa: data.empresa || "—",
               estado: data.estado || "ativo",
+              professorId: data.professorId || "",
+              professorNome: data.professorNome || "—",
             });
           }
 
@@ -137,6 +157,16 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
           <ArrowLeft className="mr-2 h-4 w-4" />
           Trocar escola
         </Button>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Pesquisar por professor, aluno, empresa ou título..."
+          className="pl-9"
+        />
       </div>
 
       <div className="overflow-hidden rounded-lg border border-border">
@@ -172,11 +202,15 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
         <CardContent>
           {loading ? (
             <p className="text-sm text-muted-foreground">A carregar estágios...</p>
-          ) : estagios.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Ainda não existem estágios atribuídos nesta escola.</p>
+          ) : filteredEstagios.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {search.trim()
+                ? "Nenhum estágio encontrado para esta pesquisa."
+                : "Ainda não existem estágios atribuídos nesta escola."}
+            </p>
           ) : (
             <div className="space-y-3">
-              {estagios.map((estagio) => (
+              {filteredEstagios.map((estagio) => (
                 <div key={estagio.id} className="rounded-lg border border-border p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
@@ -191,6 +225,7 @@ export function TutorSchoolInternships({ schoolId }: { schoolId: string }) {
                       <p className="text-xs text-muted-foreground">{estagio.alunoEmail || "Sem email"}</p>
                       <p className="text-sm text-foreground">{estagio.titulo}</p>
                       <p className="text-xs text-muted-foreground">Empresa: {estagio.empresa}</p>
+                      <p className="text-xs text-muted-foreground">Orientador: {estagio.professorNome}</p>
                     </div>
                     <div className="flex flex-wrap gap-2">
                       <Button

--- a/firestore.rules
+++ b/firestore.rules
@@ -263,7 +263,12 @@ service cloud.firestore {
           ))
         || (isSchoolAdmin() && resource.data.schoolId == currentUserData().schoolId)
         || (isProfessor() && resource.data.schoolId == currentUserData().schoolId)
-        || (isTutor() && resource.data.role == "aluno")
+        || (isTutor()
+          && (resource.data.role == "aluno"
+            || resource.data.schoolId == currentUserData().schoolId
+            || resource.data.schoolId == currentUserData().escolaId
+            || resource.data.escolaId == currentUserData().schoolId
+            || resource.data.escolaId == currentUserData().escolaId))
         || (isStudent() && resource.data.role == "tutor");
 
       // Criação final de utilizadores vindos de pendingRegistrations (aluno/professor).

--- a/lib/chat/realtime-chat.ts
+++ b/lib/chat/realtime-chat.ts
@@ -650,6 +650,7 @@ export async function ensureAutoConversationForTutorAssignment(
       updates[`userConversations/${uid}/${conversationId}`] = {
         lastMessageText: null,
         lastMessageAt: ts,
+        lastSeenAt: ts,
         unreadCount: 0,
         isMuted: false,
       } satisfies UserConversationMeta;
@@ -789,6 +790,7 @@ export async function createConversationFromUsers(
     updates[`userConversations/${participant.uid}/${conversationId}`] = {
       lastMessageText: null,
       lastMessageAt: ts,
+      lastSeenAt: ts,
       unreadCount: 0,
       isMuted: false,
     } satisfies UserConversationMeta;

--- a/lib/chat/realtime-chat.ts
+++ b/lib/chat/realtime-chat.ts
@@ -338,10 +338,6 @@ export async function searchInternalMembers(
       for (const docSnap of usersBySchoolId.docs) mergedDocs.set(docSnap.id, docSnap);
       for (const docSnap of usersByEscolaId.docs) mergedDocs.set(docSnap.id, docSnap);
 
-      // Pre-compute eligible stage participants for tutors
-      const stageParticipants =
-        role === "tutor" ? await getEligibleStageParticipantIds(currentUserId, role) : null;
-
       for (const docSnap of Array.from(mergedDocs.values())) {
         const data = docSnap.data() as {
           nome?: string;
@@ -366,7 +362,7 @@ export async function searchInternalMembers(
 
         // Role-based eligibility filtering
         if (role === "tutor") {
-          if (!stageParticipants || !stageParticipants.has(docSnap.id)) continue;
+          // Tutors can see all same-school active users (professors, admins, students)
         } else if (role === "student") {
           if (profileRole === "encarregado") {
             // Student only sees their own EE
@@ -389,8 +385,27 @@ export async function searchInternalMembers(
 
         merged.set(profile.uid, profile);
       }
-    } catch {
-      // Ignore Firestore search errors; fallback paths may still return useful candidates.
+      console.log("[searchInternalMembers] client query: merged.size =", merged.size);
+    } catch (e) {
+      console.error("[searchInternalMembers] Firestore query error, falling back to API:", e);
+      try {
+        const res = await fetch("/api/chat/search-members", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orgId, queryText, currentUserId, currentUserRole: role }),
+        });
+        if (res.ok) {
+          const json = (await res.json()) as { members?: ChatUserProfile[] };
+          console.log("[searchInternalMembers] API fallback returned", json.members?.length ?? 0, "members");
+          if (json.members) {
+            for (const m of json.members) merged.set(m.uid, m);
+          }
+        } else {
+          console.error("[searchInternalMembers] API fallback returned", res.status, await res.text());
+        }
+      } catch (apiErr) {
+        console.error("[searchInternalMembers] API fallback also failed:", apiErr);
+      }
     }
 
     // Enrich with orgMember index — verify estado for RTDB entries
@@ -441,23 +456,24 @@ export async function searchInternalMembers(
     }
   }
 
-  // For students and teachers, also fetch their associated tutors
-  if (role === "student" || role === "teacher") {
+  // Fetch stage participants for students, teachers, and tutors
+  if (role === "student" || role === "teacher" || role === "tutor") {
     try {
       const allEligible = await getEligibleStageParticipantIds(currentUserId, role);
-      const tutorIds = Array.from(allEligible).filter(
+      const relevantIds = Array.from(allEligible).filter(
         (id) => id !== currentUserId && !merged.has(id)
       );
 
-      if (tutorIds.length > 0) {
-        const tutorProfiles = await getChatProfilesByIds(tutorIds);
-        for (const profile of tutorProfiles) {
-          if (profile.role !== "tutor") continue;
-          merged.set(profile.uid, profile);
+      if (relevantIds.length > 0) {
+        const profiles = await getChatProfilesByIds(relevantIds);
+        for (const profile of profiles) {
+          if (role === "tutor" || profile.role === "tutor") {
+            merged.set(profile.uid, profile);
+          }
         }
       }
     } catch {
-      // Optional tutor enrichment should not block standard member search.
+      // Optional enrichment should not block standard member search.
     }
   }
 
@@ -667,6 +683,21 @@ export async function ensureAutoConversationForTutorAssignment(
   }
 }
 
+async function fetchProfileViaApi(uid: string): Promise<ChatUserProfile | null> {
+  try {
+    const res = await fetch("/api/chat/get-profiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userIds: [uid] }),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { profiles?: ChatUserProfile[] };
+    return json.profiles?.[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function getChatProfilesByIds(userIds: string[]): Promise<ChatUserProfile[]> {
   const fsDb = await getDbRuntime();
   const profiles = await Promise.all(
@@ -693,7 +724,8 @@ export async function getChatProfilesByIds(userIds: string[]): Promise<ChatUserP
           orgId: getOrgIdFromUserData(data),
         } satisfies ChatUserProfile;
       } catch {
-        return null;
+        // Client SDK failed (security rules), fallback to Admin SDK API
+        return fetchProfileViaApi(uid);
       }
     })
   );

--- a/lib/estagios/calendar-tooltip.ts
+++ b/lib/estagios/calendar-tooltip.ts
@@ -25,7 +25,11 @@ function dayEffectiveHours(
   if (req.absenceType === "partial" && typeof req.hoursAffected === "number") {
     return Math.max(0, horasDiarias - req.hoursAffected);
   }
-  return horasDiarias;
+  // Fallback for requests missing absenceType: infer from hoursAffected
+  if (typeof req.hoursAffected === "number" && req.hoursAffected > 0) {
+    return Math.max(0, horasDiarias - req.hoursAffected);
+  }
+  return 0;
 }
 
 export function calcTooltipDayInfo(

--- a/lib/estagios/date-calc.ts
+++ b/lib/estagios/date-calc.ts
@@ -144,7 +144,7 @@ export function recalcularDataFimEstimada(input: {
     return { dataFimEstimada: "", diasUteis: 0, horasPorDia: horasDiarias, totalHoras }; // concluído
   }
 
-  const diasNecessarios = Math.ceil(horasRestantes / horasDiarias) + 1; // +1 día extra para garantir horas completas
+  const diasNecessarios = Math.ceil(horasRestantes / horasDiarias);
 
   // Projetar a partir do dia seguinte a startFrom (ou hoje+1 se não fornecido)
   let cursor: Date;
@@ -324,7 +324,7 @@ export function calcularDataFimComAusencias(input: {
   const absMap = new Map<string, number>();
   for (const r of requests) {
     const isPartial = r.absenceType === "partial" && r.hoursAffected > 0;
-    absMap.set(r.targetDate, isPartial ? r.hoursAffected : 0);
+    absMap.set(r.targetDate, isPartial ? Math.max(0, horasDiarias - r.hoursAffected) : 0);
   }
 
   const [y, m, d] = startFrom.split("-").map(Number);

--- a/lib/estagios/workdays.ts
+++ b/lib/estagios/workdays.ts
@@ -127,7 +127,8 @@ export function listWorkDays(
   dataInicio: string,
   dataFim: string,
   diasSemana: DiasSemanaMap,
-  excludedDates?: Set<string>
+  excludedDates?: Set<string>,
+  includedDates?: Set<string>
 ): WorkDay[] {
   const start = parseIsoDate(dataInicio);
   const end = parseIsoDate(dataFim);
@@ -135,20 +136,23 @@ export function listWorkDays(
   if (end.getTime() < start.getTime()) return [];
 
   const anyDayActive = WEEKDAY_KEYS.some((k) => diasSemana[k]);
-  if (!anyDayActive) return [];
+  if (!anyDayActive && !includedDates?.size) return [];
 
   const holidays = getPortugueseHolidays(start.getFullYear(), end.getFullYear() + 1);
   const days: WorkDay[] = [];
   const cursor = new Date(start);
   let safety = 0;
   const HARD_LIMIT = 366 * 6; // estágio máx ~6 anos
+  const includedSet = includedDates ?? new Set<string>();
   while (cursor.getTime() <= end.getTime() && safety < HARD_LIMIT) {
     const iso = toIsoDate(cursor);
     const weekday = cursor.getDay();
     const key = WEEKDAY_KEYS[weekday];
     const isWorkday = Boolean(diasSemana[key]);
     const isHoliday = holidays.has(iso);
-    if (isWorkday && !isHoliday && !excludedDates?.has(iso)) {
+    const isIncluded = includedSet.has(iso);
+    if (excludedDates?.has(iso)) continue;
+    if ((isWorkday && !isHoliday) || isIncluded) {
       const isoWeek = getIsoWeek(cursor);
       const relativeWeekNumber = getRelativeWeekNumber(cursor, start);
       const weekStart = getIsoWeekStart(cursor);

--- a/lib/estagios/workdays.ts
+++ b/lib/estagios/workdays.ts
@@ -151,7 +151,11 @@ export function listWorkDays(
     const isWorkday = Boolean(diasSemana[key]);
     const isHoliday = holidays.has(iso);
     const isIncluded = includedSet.has(iso);
-    if (excludedDates?.has(iso)) continue;
+    if (excludedDates?.has(iso)) {
+      cursor.setDate(cursor.getDate() + 1);
+      safety += 1;
+      continue;
+    }
     if ((isWorkday && !isHoliday) || isIncluded) {
       const isoWeek = getIsoWeek(cursor);
       const relativeWeekNumber = getRelativeWeekNumber(cursor, start);

--- a/lib/use-sidebar-collapsed.ts
+++ b/lib/use-sidebar-collapsed.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "sidebar-collapsed";
+
+export function useSidebarCollapsed() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === "true") setCollapsed(true);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
+
+  return { collapsed, toggle };
+}

--- a/tests/actions/calendar-tooltip.test.ts
+++ b/tests/actions/calendar-tooltip.test.ts
@@ -269,6 +269,46 @@ describe("base schedule change 7h -> 7.5h", () => {
 });
 
 // ---------------------------------------------------------------------------
+// absenceType fallback when field is missing
+// ---------------------------------------------------------------------------
+describe("absenceType fallback when field is missing", () => {
+  it("request without absenceType but hoursAffected=0 → treated as total absence (previstasDia=0)", () => {
+    const r = fixt("2026-05-13", {
+      requestsByDate: reqs([["2026-05-13", { status: "approved", hoursAffected: 0 }]]),
+    });
+    expect(r.previstasDia).toBe(0);
+  });
+
+  it("request without absenceType but hoursAffected=0 → 0 in acumuladas", () => {
+    const r = fixt("2026-05-14", {
+      workDays: [{ iso: "2026-05-12" }, { iso: "2026-05-13" }, { iso: "2026-05-14" }],
+      presencas: { "2026-05-12": { hoursWorked: 7 } },
+      presencaSet: presencaSetFrom("2026-05-12"),
+      requestsByDate: reqs([["2026-05-13", { status: "approved", hoursAffected: 0 }]]),
+      horasDiarias: 7.5,
+    });
+    expect(r.acumuladas).toBe(14.5); // 7 (real) + 0 (absence) + 7.5 (predicted)
+  });
+
+  it("request without absenceType but hoursAffected>0 → treated as partial absence", () => {
+    const r = fixt("2026-05-13", {
+      requestsByDate: reqs([["2026-05-13", { status: "approved", hoursAffected: 3 }]]),
+      horasDiarias: 7.5,
+    });
+    expect(r.previstasDia).toBe(4.5);
+  });
+
+  it("request without absenceType and hoursAffected>0 → reduced in acumuladas", () => {
+    const r = fixt("2026-05-14", {
+      workDays: [{ iso: "2026-05-12" }, { iso: "2026-05-13" }, { iso: "2026-05-14" }],
+      requestsByDate: reqs([["2026-05-13", { status: "approved", hoursAffected: 3 }]]),
+      horasDiarias: 7.5,
+    });
+    expect(r.acumuladas).toBe(19.5); // 7.5 + 4.5 + 7.5
+  });
+});
+
+// ---------------------------------------------------------------------------
 // edge cases
 // ---------------------------------------------------------------------------
 describe("edge cases", () => {

--- a/tests/actions/calendar-tooltip.test.ts
+++ b/tests/actions/calendar-tooltip.test.ts
@@ -309,6 +309,62 @@ describe("absenceType fallback when field is missing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// holiday work (isHolidayWork) — day was a holiday but user opted to work
+// ---------------------------------------------------------------------------
+describe("holiday work", () => {
+  it("hasRegistered=true when presenca exists on a holiday (hoursWorked>0)", () => {
+    const r = fixt("2026-06-10", {
+      workDays: [{ iso: "2026-06-08" }, { iso: "2026-06-09" }, { iso: "2026-06-10" }, { iso: "2026-06-11" }],
+      presencas: { "2026-06-10": { hoursWorked: 5 } },
+      presencaSet: presencaSetFrom("2026-06-10"),
+      horasDiarias: 7.5,
+    });
+    expect(r.hasRegistered).toBe(true);
+    expect(r.registadasDia).toBe(5);
+    expect(r.previstasDia).toBe(7.5); // no request, so full horasDiarias
+  });
+
+  it("hasRegistered=false when holiday work set for future (hoursWorked=0, no presencaSet)", () => {
+    const r = fixt("2026-06-10", {
+      workDays: [{ iso: "2026-06-08" }, { iso: "2026-06-09" }, { iso: "2026-06-10" }, { iso: "2026-06-11" }],
+      presencas: { "2026-06-10": { hoursWorked: 0 } },
+      presencaSet: presencaSetFrom(), // 0h not in set
+      horasDiarias: 7.5,
+    });
+    expect(r.hasRegistered).toBe(false);
+    expect(r.registadasDia).toBe(0);
+    expect(r.previstasDia).toBe(7.5);
+  });
+
+  it("acumuladas includes real hours from a past holiday work day", () => {
+    const r = fixt("2026-06-10", {
+      workDays: [{ iso: "2026-06-08" }, { iso: "2026-06-09" }, { iso: "2026-06-10" }],
+      presencas: {
+        "2026-06-08": { hoursWorked: 7 },
+        "2026-06-09": { hoursWorked: 7 },
+        "2026-06-10": { hoursWorked: 5 },
+      },
+      presencaSet: presencaSetFrom("2026-06-08", "2026-06-09", "2026-06-10"),
+      horasDiarias: 7.5,
+    });
+    expect(r.acumuladas).toBe(19); // 7 + 7 + 5
+  });
+
+  it("acumuladas uses horasDiarias for future holiday work day (no presenca)", () => {
+    const r = fixt("2026-06-10", {
+      workDays: [{ iso: "2026-06-08" }, { iso: "2026-06-09" }, { iso: "2026-06-10" }],
+      presencas: {
+        "2026-06-08": { hoursWorked: 7 },
+        "2026-06-09": { hoursWorked: 7 },
+      },
+      presencaSet: presencaSetFrom("2026-06-08", "2026-06-09"),
+      horasDiarias: 7.5,
+    });
+    expect(r.acumuladas).toBe(21.5); // 7 + 7 + 7.5 (predicted for holiday)
+  });
+});
+
+// ---------------------------------------------------------------------------
 // edge cases
 // ---------------------------------------------------------------------------
 describe("edge cases", () => {

--- a/tests/actions/dashboard-layout.integration.test.tsx
+++ b/tests/actions/dashboard-layout.integration.test.tsx
@@ -98,6 +98,7 @@ vi.mock("lucide-react", () => {
     MessageSquare: Icon,
     LogOut: Icon,
     Menu: Icon,
+    PanelLeftClose: Icon,
     User: Icon,
   };
 });

--- a/tests/actions/date-calc.test.ts
+++ b/tests/actions/date-calc.test.ts
@@ -53,7 +53,7 @@ function testPipeline(
   });
   expect(raw.dataFimEstimada).toBe(want.rawDate);
   expect(raw.diasUteis).toBe(want.diasUteis);
-  assertHorasUltimoDia(totalHoras, horasRestantes, want.diasUteis, horasDiarias, true);
+  assertHorasUltimoDia(totalHoras, horasRestantes, want.diasUteis, horasDiarias);
 
   // 2) Replay de ausências
   const replayRequests: ReplayRequest[] = requests.map((r) => ({
@@ -89,12 +89,9 @@ function assertHorasUltimoDia(
   horasRestantes: number,
   diasUteis: number,
   horasDiarias: number,
-  isRecalcular: boolean,
 ) {
   if (diasUteis <= 0) return;
-  const diasReais = isRecalcular ? diasUteis - 1 : diasUteis;
-  if (diasReais <= 0) return;
-  const horasUltimoDia = horasRestantes - (diasReais - 1) * horasDiarias;
+  const horasUltimoDia = horasRestantes - (diasUteis - 1) * horasDiarias;
   expect(horasUltimoDia).toBeGreaterThan(0);
   expect(horasUltimoDia).toBeLessThanOrEqual(horasDiarias);
 }
@@ -150,11 +147,11 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 7,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-07-06",         // ceil(153/8)+1 = 21 days
-        diasUteis: 21,
-        excessPushes: 1,               // old=8 pushes, new=7 pushes
+        rawDate: "2026-07-03",         // ceil(153/8) = 20 days
+        diasUteis: 20,
+        excessPushes: 1,
         correctAcc: 3,
-        realDate: "2026-07-08",        // walk: 23 days, last=Jul 8
+        realDate: "2026-07-08",
         realDays: 23,
         realInicio: 395,
         realFim: 403,
@@ -166,7 +163,7 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
     //   Walk: Jun 5 (partial 4h) → 402 ≥ 400 ✓  last=2026-06-05
     // ════════════════════════════════════════════════════════════════════
     {
-      name: "2h restantes + 1 partial 4h: raw=2026-06-08, real=2026-06-05",
+      name: "2h restantes + 1 partial 4h: raw=2026-06-05, real=2026-06-05",
       totalHoras: 400, horasRealizadas: 398, horasDiarias: 8, diasSemana: segSex, startFrom: "2026-06-03",
       requests: [
         { targetDate: "2026-06-05", isPartial: true, hoursAffected: 4 },
@@ -174,11 +171,11 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 0,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-06-08",         // ceil(2/8)+1 = 2 days
-        diasUteis: 2,
+        rawDate: "2026-06-05",         // ceil(2/8) = 1 day
+        diasUteis: 1,
         excessPushes: 1,
         correctAcc: 4,
-        realDate: "2026-06-05",        // 1 day, partial 4h → completes
+        realDate: "2026-06-05",
         realDays: 1,
         realInicio: 398,
         realFim: 402,
@@ -188,8 +185,6 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
     // ════════════════════════════════════════════════════════════════════
     // 400h scratch + 1 total on 2026-05-04 (Monday after Labour Day)
     //   Walk: May 4 → 0h. Precisa de 51 dias (50×8h + 1×0h = 400h)
-    //   Sem ausência: 50 dias → Jun 25
-    //   Com ausência: 51 dias → Jun 26
     // ════════════════════════════════════════════════════════════════════
     {
       name: "400h scratch + 1 total on 2026-05-04: real=2026-06-26",
@@ -200,9 +195,9 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 0,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-06-26",        // ceil(400/8)+1 = 51
-        diasUteis: 51,
-        excessPushes: 0,              // total absence: same on old+new paths
+        rawDate: "2026-06-25",        // ceil(400/8) = 50
+        diasUteis: 50,
+        excessPushes: 0,
         correctAcc: 0,
         realDate: "2026-06-26",       // 51 days (50×8h + 1×0h)
         realDays: 51,
@@ -217,7 +212,7 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
     //   2026-06-13 (Sat): partial 4h
     // ════════════════════════════════════════════════════════════════════
     {
-      name: "only saturday + 2 partial 4h: real=2026-09-05",
+      name: "only saturday + 2 partial 4h: real=2026-09-12",
       totalHoras: 200, horasRealizadas: 100, horasDiarias: 8, diasSemana: onlySab, startFrom: "2026-06-03",
       requests: [
         { targetDate: "2026-06-06", isPartial: true, hoursAffected: 4 },
@@ -226,8 +221,8 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 0,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-09-12",
-        diasUteis: 14,
+        rawDate: "2026-09-05",
+        diasUteis: 13,
         excessPushes: 1,
         correctAcc: 0,
         realDate: "2026-09-12",
@@ -239,7 +234,7 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
 
     // ════════════════════════════════════════════════════════════════════
     // 200h restantes + 1 partial 6h on 2026-06-05
-    //   Walk: Jun 5 (6h) + 25×8h = 206h. Último dia = Jul 13 (26th day).
+    //   Walk: Jun 5 (2h) + 25×8h = 202h. Último dia = Jul 13 (26th day).
     // ════════════════════════════════════════════════════════════════════
     {
       name: "200h restantes + 1 partial 6h: real=2026-07-13",
@@ -250,21 +245,20 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 0,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-07-13",
-        diasUteis: 26,
+        rawDate: "2026-07-10",
+        diasUteis: 25,
         excessPushes: 1,
         correctAcc: 6,
         realDate: "2026-07-13",
         realDays: 26,
-        realInicio: 398,
-        realFim: 406,
+        realInicio: 394,
+        realFim: 402,
       },
     },
 
     // ════════════════════════════════════════════════════════════════════
     // 8h scratch + 1 partial 2h (preAcc=6 carry) on 2026-06-11
-    //   Walk: Jun 11 (2h) → acc=2 (<8). Jun 12 (8h) → acc=10 ≥ 8 ✓
-    //   preAcc=6 é do replay (counter), não afeta walk real.
+    //   Walk: Jun 11 (6h) → acc=6 (<8). Jun 12 (8h) → acc=14 ≥ 8 ✓
     // ════════════════════════════════════════════════════════════════════
     {
       name: "8h scratch + 1 partial 2h (preAcc=6 carry): real=2026-06-12",
@@ -275,21 +269,19 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 6,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-06-12",
-        diasUteis: 2,
+        rawDate: "2026-06-11",
+        diasUteis: 1,
         excessPushes: 0,
         correctAcc: 0,
         realDate: "2026-06-12",
         realDays: 2,
-        realInicio: 2,
-        realFim: 10,
+        realInicio: 6,
+        realFim: 14,
       },
     },
 
     // ════════════════════════════════════════════════════════════════════
     // 3 partial 4h (preAcc=7) — simplified CASO REAL sem total/closure
-    //   Ausências em 2026-06-16, 2026-06-23, 2026-06-30
-    //   Perde 12h (3×4h) vs raw 8h/dia → precisa +1 dia. 21 dias → Jul 6.
     // ════════════════════════════════════════════════════════════════════
     {
       name: "3 partial 4h (preAcc=7): 153h restantes, 3×4h ausências",
@@ -302,8 +294,8 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 7,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-07-06",
-        diasUteis: 21,
+        rawDate: "2026-07-03",
+        diasUteis: 20,
         excessPushes: 1,
         correctAcc: 3,
         realDate: "2026-07-06",
@@ -314,10 +306,7 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
     },
 
     // ════════════════════════════════════════════════════════════════════
-    // CASO PÓS-PATCH: 260h realizadas, 4 ausências (sem closure Jun 5,
-    // que está antes do startFromProjecao). startFrom=Jun 8 para
-    // simular o safeguard que cap ultimaPresenca a ontem.
-    //   Walk: Jun 9 a Jul 7 = 20 dias, acum 392→400 (exactas).
+    // CASO PÓS-PATCH: 260h realizadas, 4 ausências, startFrom=Jun 8
     // ════════════════════════════════════════════════════════════════════
     {
       name: "PÓS-PATCH: 260h, 4 ausências, startFrom=Jun 8 → Jul 7 com 400h exactas",
@@ -331,8 +320,8 @@ describe("recalcularDataFimEstimada — full pipeline", () => {
       preAcc: 7,
       guardCurrentDate: null,
       want: {
-        rawDate: "2026-07-06",
-        diasUteis: 19,
+        rawDate: "2026-07-03",
+        diasUteis: 18,
         excessPushes: 1,
         correctAcc: 3,
         realDate: "2026-07-07",
@@ -409,7 +398,7 @@ describe("calcularDataFimEstimada", () => {
     });
     expect(result.dataFimEstimada).toBe("2026-06-24");
     expect(result.diasUteis).toBe(50);
-    assertHorasUltimoDia(400, 400, 50, 8, false);
+    assertHorasUltimoDia(400, 400, 50, 8);
   });
 
   it("400h from 2026-04-13, 6h/dia", () => {
@@ -423,7 +412,7 @@ describe("calcularDataFimEstimada", () => {
     const d = new Date(result.dataFimEstimada);
     expect(d.getDay()).not.toBe(0);
     expect(d.getDay()).not.toBe(6);
-    assertHorasUltimoDia(400, 400, 67, 6, false);
+    assertHorasUltimoDia(400, 400, 67, 6);
   });
 
   it("only saturday, 400h from 2026-04-13", () => {
@@ -436,7 +425,7 @@ describe("calcularDataFimEstimada", () => {
     expect(result.diasUteis).toBe(50);
     const d = new Date(result.dataFimEstimada);
     expect(d.getDay()).toBe(6);
-    assertHorasUltimoDia(400, 400, 50, 8, false);
+    assertHorasUltimoDia(400, 400, 50, 8);
   });
 
   it("empty when no workdays", () => {

--- a/tests/actions/professor-layout.integration.test.tsx
+++ b/tests/actions/professor-layout.integration.test.tsx
@@ -119,6 +119,7 @@ vi.mock("lucide-react", () => {
     LogOut: Icon,
     Menu: Icon,
     MessageSquare: Icon,
+    PanelLeftClose: Icon,
     User: Icon,
   };
 });

--- a/tests/actions/school-admin-layout.integration.test.tsx
+++ b/tests/actions/school-admin-layout.integration.test.tsx
@@ -99,6 +99,7 @@ vi.mock("lucide-react", () => {
     Building2: Icon,
     LogOut: Icon,
     Menu: Icon,
+    PanelLeftClose: Icon,
   };
 });
 

--- a/tests/actions/workdays.test.ts
+++ b/tests/actions/workdays.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { listWorkDays } from "@/lib/estagios/workdays";
+import type { DiasSemanaMap } from "@/lib/estagios/workdays";
+
+const SEG_SEX: DiasSemanaMap = {
+  seg: true,
+  ter: true,
+  qua: true,
+  qui: true,
+  sex: true,
+};
+
+describe("listWorkDays — includedDates", () => {
+  it("includes a holiday date passed in includedDates", () => {
+    // 2026-06-10 is Dia de Portugal (feriado), a Wednesday
+    const result = listWorkDays("2026-06-08", "2026-06-12", SEG_SEX, undefined, new Set(["2026-06-10"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).toContain("2026-06-10"); // holiday included via includedDates
+    expect(isos).toContain("2026-06-08"); // normal workday
+    expect(isos).toContain("2026-06-09"); // normal workday
+    expect(isos).toContain("2026-06-11"); // normal workday
+    expect(isos).toContain("2026-06-12"); // normal workday
+  });
+
+  it("includes multiple holiday dates", () => {
+    // 2026-04-25 (Liberdade, Sat) and 2026-05-01 (Trabalhador, Fri)
+    const result = listWorkDays("2026-04-20", "2026-05-08", SEG_SEX, undefined, new Set(["2026-04-25", "2026-05-01"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).toContain("2026-04-25");
+    expect(isos).toContain("2026-05-01");
+  });
+
+  it("does not include a holiday when not in includedDates", () => {
+    const result = listWorkDays("2026-06-08", "2026-06-12", SEG_SEX);
+    const isos = result.map((d) => d.iso);
+    expect(isos).not.toContain("2026-06-10"); // holiday not included
+  });
+
+  it("includes a date that is not a normal workday (e.g., Saturday)", () => {
+    // 2026-06-13 is a Saturday, not in SEG_SEX
+    const result = listWorkDays("2026-06-08", "2026-06-15", SEG_SEX, undefined, new Set(["2026-06-13"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).toContain("2026-06-13");
+  });
+
+  it("excludedDates takes precedence over includedDates", () => {
+    const result = listWorkDays("2026-06-08", "2026-06-12", SEG_SEX, new Set(["2026-06-10"]), new Set(["2026-06-10"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).not.toContain("2026-06-10");
+  });
+
+  it("included date respects the date range", () => {
+    const result = listWorkDays("2026-06-08", "2026-06-12", SEG_SEX, undefined, new Set(["2026-06-20"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).not.toContain("2026-06-20"); // outside range
+  });
+
+  it("returns empty array when no workdays active and no includedDates", () => {
+    const result = listWorkDays("2026-06-08", "2026-06-12", {});
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns included date even when no workdays active", () => {
+    const result = listWorkDays("2026-06-08", "2026-06-12", {}, undefined, new Set(["2026-06-10"]));
+    const isos = result.map((d) => d.iso);
+    expect(isos).toContain("2026-06-10");
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -7,4 +7,7 @@ export default defineConfig({
       "@": path.resolve("."),
     },
   },
+  test: {
+    exclude: ["**/node_modules/**", "**/dist/**", "**/*.test.mjs"],
+  },
 });


### PR DESCRIPTION
### Alterações no calendário

**UI do calendário** — calendario-tab.tsx
- Preenchimentos (fill) apenas para: verde (dentro do esperado), azul (dia atual), amarelo (horas abaixo), roxo (feriados)
- Orlas (rings) para: azul (dia previsto), verde/vermelho/amarelo (estados de pedidos)
- Término antecipado convertido de fill+border para ring apenas
- Removidos fills específicos de tipo de pedido (justificação, falta futura, etc.)
- Legenda atualizada

**Correção de bugs** — date-calc.ts
- recalcularDataFimEstimada: removido +1 espúrio em Math.ceil(horasRestantes / horasDiarias)
- calcularDataFimComAusencias: faltas parciais somavam hoursAffected (horas ausente) em vez de horasDiarias - hoursAffected (horas trabalhadas)

### Testes
- 39 testes passam